### PR TITLE
#9 Implement usecase, login api, parser, error handlers

### DIFF
--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -1,11 +1,13 @@
 import 'package:dio/dio.dart';
 import 'package:retrofit/http.dart';
+import 'package:survey/api/request/oauth_token_request.dart';
+import 'package:survey/models/auth_token.dart';
 import 'package:survey/models/user.dart';
 
 part 'api_client.g.dart';
 
 class Apis {
-  static const String oauthLogin = '/api/v1/oauth/token';
+  static const String oauthToken = '/api/v1/oauth/token';
   static const String me = '/api/v1/me';
 }
 
@@ -15,4 +17,7 @@ abstract class ApiClient {
 
   @GET(Apis.me)
   Future<UserResponseData> getUser();
+
+  @POST(Apis.oauthToken)
+  Future<AuthTokenResponseData> login(@Body() OAuthTokenRequest body);
 }

--- a/lib/api/api_client.g.dart
+++ b/lib/api/api_client.g.dart
@@ -31,4 +31,24 @@ class _ApiClient implements ApiClient {
     final value = UserResponseData.fromJson(_result.data);
     return value;
   }
+
+  @override
+  Future<AuthTokenResponseData> login(body) async {
+    ArgumentError.checkNotNull(body, 'body');
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body?.toJson() ?? <String, dynamic>{});
+    final _result = await _dio.request<Map<String, dynamic>>(
+        '/api/v1/oauth/token',
+        queryParameters: queryParameters,
+        options: RequestOptions(
+            method: 'POST',
+            headers: <String, dynamic>{},
+            extra: _extra,
+            baseUrl: baseUrl),
+        data: _data);
+    final value = AuthTokenResponseData.fromJson(_result.data);
+    return value;
+  }
 }

--- a/lib/api/request/api_const.dart
+++ b/lib/api/request/api_const.dart
@@ -1,0 +1,1 @@
+const String GRANT_TYPE_PASSWORD = "password";

--- a/lib/api/request/oauth_token_request.dart
+++ b/lib/api/request/oauth_token_request.dart
@@ -1,0 +1,31 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import 'api_const.dart';
+
+part 'oauth_token_request.g.dart';
+
+@JsonSerializable()
+class OAuthTokenRequest {
+  @JsonKey(name: 'grant_type')
+  String grantType;
+  @JsonKey(name: 'email')
+  String email;
+  @JsonKey(name: 'password')
+  String password;
+  @JsonKey(name: 'client_id')
+  String clientId;
+  @JsonKey(name: 'client_secret')
+  String clientSecret;
+
+  OAuthTokenRequest(
+      {this.grantType = GRANT_TYPE_PASSWORD,
+      this.email,
+      this.password,
+      this.clientId,
+      this.clientSecret});
+
+  factory OAuthTokenRequest.fromJson(Map<String, dynamic> json) =>
+      _$OAuthTokenRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$OAuthTokenRequestToJson(this);
+}

--- a/lib/api/request/oauth_token_request.g.dart
+++ b/lib/api/request/oauth_token_request.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'oauth_token_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+OAuthTokenRequest _$OAuthTokenRequestFromJson(Map<String, dynamic> json) {
+  return OAuthTokenRequest(
+    grantType: json['grant_type'] as String,
+    email: json['email'] as String,
+    password: json['password'] as String,
+    clientId: json['client_id'] as String,
+    clientSecret: json['client_secret'] as String,
+  );
+}
+
+Map<String, dynamic> _$OAuthTokenRequestToJson(OAuthTokenRequest instance) =>
+    <String, dynamic>{
+      'grant_type': instance.grantType,
+      'email': instance.email,
+      'password': instance.password,
+      'client_id': instance.clientId,
+      'client_secret': instance.clientSecret,
+    };

--- a/lib/exception/network_exceptions.dart
+++ b/lib/exception/network_exceptions.dart
@@ -1,0 +1,159 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'network_exceptions.freezed.dart';
+
+@freezed
+abstract class NetworkExceptions with _$NetworkExceptions {
+  const factory NetworkExceptions.requestCancelled() = RequestCancelled;
+
+  const factory NetworkExceptions.unauthorisedRequest() = UnauthorisedRequest;
+
+  const factory NetworkExceptions.badRequest() = BadRequest;
+
+  const factory NetworkExceptions.notFound(String reason) = NotFound;
+
+  const factory NetworkExceptions.methodNotAllowed() = MethodNotAllowed;
+
+  const factory NetworkExceptions.notAcceptable() = NotAcceptable;
+
+  const factory NetworkExceptions.requestTimeout() = RequestTimeout;
+
+  const factory NetworkExceptions.sendTimeout() = SendTimeout;
+
+  const factory NetworkExceptions.conflict() = Conflict;
+
+  const factory NetworkExceptions.internalServerError() = InternalServerError;
+
+  const factory NetworkExceptions.notImplemented() = NotImplemented;
+
+  const factory NetworkExceptions.serviceUnavailable() = ServiceUnavailable;
+
+  const factory NetworkExceptions.noInternetConnection() = NoInternetConnection;
+
+  const factory NetworkExceptions.formatException() = FormatException;
+
+  const factory NetworkExceptions.unableToProcess() = UnableToProcess;
+
+  const factory NetworkExceptions.defaultError(String error) = DefaultError;
+
+  const factory NetworkExceptions.unexpectedError() = UnexpectedError;
+
+  static NetworkExceptions getDioException(error) {
+    if (error is Exception) {
+      try {
+        NetworkExceptions networkExceptions;
+        if (error is DioError) {
+          switch (error.type) {
+            case DioErrorType.CANCEL:
+              networkExceptions = NetworkExceptions.requestCancelled();
+              break;
+            case DioErrorType.CONNECT_TIMEOUT:
+              networkExceptions = NetworkExceptions.requestTimeout();
+              break;
+            case DioErrorType.DEFAULT:
+              networkExceptions = NetworkExceptions.noInternetConnection();
+              break;
+            case DioErrorType.RECEIVE_TIMEOUT:
+              networkExceptions = NetworkExceptions.sendTimeout();
+              break;
+            case DioErrorType.RESPONSE:
+              switch (error.response.statusCode) {
+                case 400:
+                  networkExceptions = NetworkExceptions.unauthorisedRequest();
+                  break;
+                case 401:
+                  networkExceptions = NetworkExceptions.unauthorisedRequest();
+                  break;
+                case 403:
+                  networkExceptions = NetworkExceptions.unauthorisedRequest();
+                  break;
+                case 404:
+                  networkExceptions = NetworkExceptions.notFound("Not found");
+                  break;
+                case 409:
+                  networkExceptions = NetworkExceptions.conflict();
+                  break;
+                case 408:
+                  networkExceptions = NetworkExceptions.requestTimeout();
+                  break;
+                case 500:
+                  networkExceptions = NetworkExceptions.internalServerError();
+                  break;
+                case 503:
+                  networkExceptions = NetworkExceptions.serviceUnavailable();
+                  break;
+                default:
+                  var responseCode = error.response.statusCode;
+                  networkExceptions = NetworkExceptions.defaultError(
+                    "Received invalid status code: $responseCode",
+                  );
+              }
+              break;
+            case DioErrorType.SEND_TIMEOUT:
+              networkExceptions = NetworkExceptions.sendTimeout();
+              break;
+          }
+        } else if (error is SocketException) {
+          networkExceptions = NetworkExceptions.noInternetConnection();
+        } else {
+          networkExceptions = NetworkExceptions.unexpectedError();
+        }
+        return networkExceptions;
+      } on FormatException catch (e) {
+        // Helper.printError(e.toString());
+        return NetworkExceptions.formatException();
+      } catch (_) {
+        return NetworkExceptions.unexpectedError();
+      }
+    } else {
+      if (error.toString().contains("is not a subtype of")) {
+        return NetworkExceptions.unableToProcess();
+      } else {
+        return NetworkExceptions.unexpectedError();
+      }
+    }
+  }
+
+  static String getErrorMessage(NetworkExceptions networkExceptions) {
+    var errorMessage = "";
+    networkExceptions.when(notImplemented: () {
+      errorMessage = "Not Implemented";
+    }, requestCancelled: () {
+      errorMessage = "Request Cancelled";
+    }, internalServerError: () {
+      errorMessage = "Internal Server Error";
+    }, notFound: (String reason) {
+      errorMessage = reason;
+    }, serviceUnavailable: () {
+      errorMessage = "Service unavailable";
+    }, methodNotAllowed: () {
+      errorMessage = "Method Allowed";
+    }, badRequest: () {
+      errorMessage = "Bad request";
+    }, unauthorisedRequest: () {
+      errorMessage = "Unauthorised request";
+    }, unexpectedError: () {
+      errorMessage = "Unexpected error occurred";
+    }, requestTimeout: () {
+      errorMessage = "Connection request timeout";
+    }, noInternetConnection: () {
+      errorMessage = "No internet connection";
+    }, conflict: () {
+      errorMessage = "Error due to a conflict";
+    }, sendTimeout: () {
+      errorMessage = "Send timeout in connection with API server";
+    }, unableToProcess: () {
+      errorMessage = "Unable to process the data";
+    }, defaultError: (String error) {
+      errorMessage = error;
+    }, formatException: () {
+      errorMessage = "Unexpected error occurred";
+    }, notAcceptable: () {
+      errorMessage = "Not acceptable";
+    });
+    return errorMessage;
+  }
+}

--- a/lib/exception/network_exceptions.dart
+++ b/lib/exception/network_exceptions.dart
@@ -102,7 +102,7 @@ abstract class NetworkExceptions with _$NetworkExceptions {
           networkExceptions = NetworkExceptions.unexpectedError();
         }
         return networkExceptions;
-      } on FormatException catch (e) {
+      } on FormatException catch (_) {
         // Helper.printError(e.toString());
         return NetworkExceptions.formatException();
       } catch (_) {

--- a/lib/exception/network_exceptions.freezed.dart
+++ b/lib/exception/network_exceptions.freezed.dart
@@ -1,0 +1,3341 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
+
+part of 'network_exceptions.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+class _$NetworkExceptionsTearOff {
+  const _$NetworkExceptionsTearOff();
+
+// ignore: unused_element
+  RequestCancelled requestCancelled() {
+    return const RequestCancelled();
+  }
+
+// ignore: unused_element
+  UnauthorisedRequest unauthorisedRequest() {
+    return const UnauthorisedRequest();
+  }
+
+// ignore: unused_element
+  BadRequest badRequest() {
+    return const BadRequest();
+  }
+
+// ignore: unused_element
+  NotFound notFound(String reason) {
+    return NotFound(
+      reason,
+    );
+  }
+
+// ignore: unused_element
+  MethodNotAllowed methodNotAllowed() {
+    return const MethodNotAllowed();
+  }
+
+// ignore: unused_element
+  NotAcceptable notAcceptable() {
+    return const NotAcceptable();
+  }
+
+// ignore: unused_element
+  RequestTimeout requestTimeout() {
+    return const RequestTimeout();
+  }
+
+// ignore: unused_element
+  SendTimeout sendTimeout() {
+    return const SendTimeout();
+  }
+
+// ignore: unused_element
+  Conflict conflict() {
+    return const Conflict();
+  }
+
+// ignore: unused_element
+  InternalServerError internalServerError() {
+    return const InternalServerError();
+  }
+
+// ignore: unused_element
+  NotImplemented notImplemented() {
+    return const NotImplemented();
+  }
+
+// ignore: unused_element
+  ServiceUnavailable serviceUnavailable() {
+    return const ServiceUnavailable();
+  }
+
+// ignore: unused_element
+  NoInternetConnection noInternetConnection() {
+    return const NoInternetConnection();
+  }
+
+// ignore: unused_element
+  FormatException formatException() {
+    return const FormatException();
+  }
+
+// ignore: unused_element
+  UnableToProcess unableToProcess() {
+    return const UnableToProcess();
+  }
+
+// ignore: unused_element
+  DefaultError defaultError(String error) {
+    return DefaultError(
+      error,
+    );
+  }
+
+// ignore: unused_element
+  UnexpectedError unexpectedError() {
+    return const UnexpectedError();
+  }
+}
+
+/// @nodoc
+// ignore: unused_element
+const $NetworkExceptions = _$NetworkExceptionsTearOff();
+
+/// @nodoc
+mixin _$NetworkExceptions {
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  });
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  });
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  });
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  });
+}
+
+/// @nodoc
+abstract class $NetworkExceptionsCopyWith<$Res> {
+  factory $NetworkExceptionsCopyWith(
+          NetworkExceptions value, $Res Function(NetworkExceptions) then) =
+      _$NetworkExceptionsCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $NetworkExceptionsCopyWith<$Res> {
+  _$NetworkExceptionsCopyWithImpl(this._value, this._then);
+
+  final NetworkExceptions _value;
+
+  // ignore: unused_field
+  final $Res Function(NetworkExceptions) _then;
+}
+
+/// @nodoc
+abstract class $RequestCancelledCopyWith<$Res> {
+  factory $RequestCancelledCopyWith(
+          RequestCancelled value, $Res Function(RequestCancelled) then) =
+      _$RequestCancelledCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$RequestCancelledCopyWithImpl<$Res>
+    extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $RequestCancelledCopyWith<$Res> {
+  _$RequestCancelledCopyWithImpl(
+      RequestCancelled _value, $Res Function(RequestCancelled) _then)
+      : super(_value, (v) => _then(v as RequestCancelled));
+
+  @override
+  RequestCancelled get _value => super._value as RequestCancelled;
+}
+
+/// @nodoc
+class _$RequestCancelled implements RequestCancelled {
+  const _$RequestCancelled();
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.requestCancelled()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) || (other is RequestCancelled);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return requestCancelled();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (requestCancelled != null) {
+      return requestCancelled();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return requestCancelled(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (requestCancelled != null) {
+      return requestCancelled(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class RequestCancelled implements NetworkExceptions {
+  const factory RequestCancelled() = _$RequestCancelled;
+}
+
+/// @nodoc
+abstract class $UnauthorisedRequestCopyWith<$Res> {
+  factory $UnauthorisedRequestCopyWith(
+          UnauthorisedRequest value, $Res Function(UnauthorisedRequest) then) =
+      _$UnauthorisedRequestCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$UnauthorisedRequestCopyWithImpl<$Res>
+    extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $UnauthorisedRequestCopyWith<$Res> {
+  _$UnauthorisedRequestCopyWithImpl(
+      UnauthorisedRequest _value, $Res Function(UnauthorisedRequest) _then)
+      : super(_value, (v) => _then(v as UnauthorisedRequest));
+
+  @override
+  UnauthorisedRequest get _value => super._value as UnauthorisedRequest;
+}
+
+/// @nodoc
+class _$UnauthorisedRequest implements UnauthorisedRequest {
+  const _$UnauthorisedRequest();
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.unauthorisedRequest()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) || (other is UnauthorisedRequest);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return unauthorisedRequest();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (unauthorisedRequest != null) {
+      return unauthorisedRequest();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return unauthorisedRequest(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (unauthorisedRequest != null) {
+      return unauthorisedRequest(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class UnauthorisedRequest implements NetworkExceptions {
+  const factory UnauthorisedRequest() = _$UnauthorisedRequest;
+}
+
+/// @nodoc
+abstract class $BadRequestCopyWith<$Res> {
+  factory $BadRequestCopyWith(
+          BadRequest value, $Res Function(BadRequest) then) =
+      _$BadRequestCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$BadRequestCopyWithImpl<$Res>
+    extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $BadRequestCopyWith<$Res> {
+  _$BadRequestCopyWithImpl(BadRequest _value, $Res Function(BadRequest) _then)
+      : super(_value, (v) => _then(v as BadRequest));
+
+  @override
+  BadRequest get _value => super._value as BadRequest;
+}
+
+/// @nodoc
+class _$BadRequest implements BadRequest {
+  const _$BadRequest();
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.badRequest()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) || (other is BadRequest);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return badRequest();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (badRequest != null) {
+      return badRequest();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return badRequest(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (badRequest != null) {
+      return badRequest(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class BadRequest implements NetworkExceptions {
+  const factory BadRequest() = _$BadRequest;
+}
+
+/// @nodoc
+abstract class $NotFoundCopyWith<$Res> {
+  factory $NotFoundCopyWith(NotFound value, $Res Function(NotFound) then) =
+      _$NotFoundCopyWithImpl<$Res>;
+
+  $Res call({String reason});
+}
+
+/// @nodoc
+class _$NotFoundCopyWithImpl<$Res> extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $NotFoundCopyWith<$Res> {
+  _$NotFoundCopyWithImpl(NotFound _value, $Res Function(NotFound) _then)
+      : super(_value, (v) => _then(v as NotFound));
+
+  @override
+  NotFound get _value => super._value as NotFound;
+
+  @override
+  $Res call({
+    Object reason = freezed,
+  }) {
+    return _then(NotFound(
+      reason == freezed ? _value.reason : reason as String,
+    ));
+  }
+}
+
+/// @nodoc
+class _$NotFound implements NotFound {
+  const _$NotFound(this.reason) : assert(reason != null);
+
+  @override
+  final String reason;
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.notFound(reason: $reason)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is NotFound &&
+            (identical(other.reason, reason) ||
+                const DeepCollectionEquality().equals(other.reason, reason)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^ const DeepCollectionEquality().hash(reason);
+
+  @JsonKey(ignore: true)
+  @override
+  $NotFoundCopyWith<NotFound> get copyWith =>
+      _$NotFoundCopyWithImpl<NotFound>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return notFound(reason);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (notFound != null) {
+      return notFound(reason);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return notFound(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (notFound != null) {
+      return notFound(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class NotFound implements NetworkExceptions {
+  const factory NotFound(String reason) = _$NotFound;
+
+  String get reason;
+
+  @JsonKey(ignore: true)
+  $NotFoundCopyWith<NotFound> get copyWith;
+}
+
+/// @nodoc
+abstract class $MethodNotAllowedCopyWith<$Res> {
+  factory $MethodNotAllowedCopyWith(
+          MethodNotAllowed value, $Res Function(MethodNotAllowed) then) =
+      _$MethodNotAllowedCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$MethodNotAllowedCopyWithImpl<$Res>
+    extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $MethodNotAllowedCopyWith<$Res> {
+  _$MethodNotAllowedCopyWithImpl(
+      MethodNotAllowed _value, $Res Function(MethodNotAllowed) _then)
+      : super(_value, (v) => _then(v as MethodNotAllowed));
+
+  @override
+  MethodNotAllowed get _value => super._value as MethodNotAllowed;
+}
+
+/// @nodoc
+class _$MethodNotAllowed implements MethodNotAllowed {
+  const _$MethodNotAllowed();
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.methodNotAllowed()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) || (other is MethodNotAllowed);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return methodNotAllowed();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (methodNotAllowed != null) {
+      return methodNotAllowed();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return methodNotAllowed(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (methodNotAllowed != null) {
+      return methodNotAllowed(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class MethodNotAllowed implements NetworkExceptions {
+  const factory MethodNotAllowed() = _$MethodNotAllowed;
+}
+
+/// @nodoc
+abstract class $NotAcceptableCopyWith<$Res> {
+  factory $NotAcceptableCopyWith(
+          NotAcceptable value, $Res Function(NotAcceptable) then) =
+      _$NotAcceptableCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$NotAcceptableCopyWithImpl<$Res>
+    extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $NotAcceptableCopyWith<$Res> {
+  _$NotAcceptableCopyWithImpl(
+      NotAcceptable _value, $Res Function(NotAcceptable) _then)
+      : super(_value, (v) => _then(v as NotAcceptable));
+
+  @override
+  NotAcceptable get _value => super._value as NotAcceptable;
+}
+
+/// @nodoc
+class _$NotAcceptable implements NotAcceptable {
+  const _$NotAcceptable();
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.notAcceptable()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) || (other is NotAcceptable);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return notAcceptable();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (notAcceptable != null) {
+      return notAcceptable();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return notAcceptable(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (notAcceptable != null) {
+      return notAcceptable(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class NotAcceptable implements NetworkExceptions {
+  const factory NotAcceptable() = _$NotAcceptable;
+}
+
+/// @nodoc
+abstract class $RequestTimeoutCopyWith<$Res> {
+  factory $RequestTimeoutCopyWith(
+          RequestTimeout value, $Res Function(RequestTimeout) then) =
+      _$RequestTimeoutCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$RequestTimeoutCopyWithImpl<$Res>
+    extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $RequestTimeoutCopyWith<$Res> {
+  _$RequestTimeoutCopyWithImpl(
+      RequestTimeout _value, $Res Function(RequestTimeout) _then)
+      : super(_value, (v) => _then(v as RequestTimeout));
+
+  @override
+  RequestTimeout get _value => super._value as RequestTimeout;
+}
+
+/// @nodoc
+class _$RequestTimeout implements RequestTimeout {
+  const _$RequestTimeout();
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.requestTimeout()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) || (other is RequestTimeout);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return requestTimeout();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (requestTimeout != null) {
+      return requestTimeout();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return requestTimeout(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (requestTimeout != null) {
+      return requestTimeout(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class RequestTimeout implements NetworkExceptions {
+  const factory RequestTimeout() = _$RequestTimeout;
+}
+
+/// @nodoc
+abstract class $SendTimeoutCopyWith<$Res> {
+  factory $SendTimeoutCopyWith(
+          SendTimeout value, $Res Function(SendTimeout) then) =
+      _$SendTimeoutCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$SendTimeoutCopyWithImpl<$Res>
+    extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $SendTimeoutCopyWith<$Res> {
+  _$SendTimeoutCopyWithImpl(
+      SendTimeout _value, $Res Function(SendTimeout) _then)
+      : super(_value, (v) => _then(v as SendTimeout));
+
+  @override
+  SendTimeout get _value => super._value as SendTimeout;
+}
+
+/// @nodoc
+class _$SendTimeout implements SendTimeout {
+  const _$SendTimeout();
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.sendTimeout()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) || (other is SendTimeout);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return sendTimeout();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (sendTimeout != null) {
+      return sendTimeout();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return sendTimeout(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (sendTimeout != null) {
+      return sendTimeout(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class SendTimeout implements NetworkExceptions {
+  const factory SendTimeout() = _$SendTimeout;
+}
+
+/// @nodoc
+abstract class $ConflictCopyWith<$Res> {
+  factory $ConflictCopyWith(Conflict value, $Res Function(Conflict) then) =
+      _$ConflictCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$ConflictCopyWithImpl<$Res> extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $ConflictCopyWith<$Res> {
+  _$ConflictCopyWithImpl(Conflict _value, $Res Function(Conflict) _then)
+      : super(_value, (v) => _then(v as Conflict));
+
+  @override
+  Conflict get _value => super._value as Conflict;
+}
+
+/// @nodoc
+class _$Conflict implements Conflict {
+  const _$Conflict();
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.conflict()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) || (other is Conflict);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return conflict();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (conflict != null) {
+      return conflict();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return conflict(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (conflict != null) {
+      return conflict(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Conflict implements NetworkExceptions {
+  const factory Conflict() = _$Conflict;
+}
+
+/// @nodoc
+abstract class $InternalServerErrorCopyWith<$Res> {
+  factory $InternalServerErrorCopyWith(
+          InternalServerError value, $Res Function(InternalServerError) then) =
+      _$InternalServerErrorCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$InternalServerErrorCopyWithImpl<$Res>
+    extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $InternalServerErrorCopyWith<$Res> {
+  _$InternalServerErrorCopyWithImpl(
+      InternalServerError _value, $Res Function(InternalServerError) _then)
+      : super(_value, (v) => _then(v as InternalServerError));
+
+  @override
+  InternalServerError get _value => super._value as InternalServerError;
+}
+
+/// @nodoc
+class _$InternalServerError implements InternalServerError {
+  const _$InternalServerError();
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.internalServerError()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) || (other is InternalServerError);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return internalServerError();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (internalServerError != null) {
+      return internalServerError();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return internalServerError(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (internalServerError != null) {
+      return internalServerError(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class InternalServerError implements NetworkExceptions {
+  const factory InternalServerError() = _$InternalServerError;
+}
+
+/// @nodoc
+abstract class $NotImplementedCopyWith<$Res> {
+  factory $NotImplementedCopyWith(
+          NotImplemented value, $Res Function(NotImplemented) then) =
+      _$NotImplementedCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$NotImplementedCopyWithImpl<$Res>
+    extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $NotImplementedCopyWith<$Res> {
+  _$NotImplementedCopyWithImpl(
+      NotImplemented _value, $Res Function(NotImplemented) _then)
+      : super(_value, (v) => _then(v as NotImplemented));
+
+  @override
+  NotImplemented get _value => super._value as NotImplemented;
+}
+
+/// @nodoc
+class _$NotImplemented implements NotImplemented {
+  const _$NotImplemented();
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.notImplemented()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) || (other is NotImplemented);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return notImplemented();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (notImplemented != null) {
+      return notImplemented();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return notImplemented(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (notImplemented != null) {
+      return notImplemented(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class NotImplemented implements NetworkExceptions {
+  const factory NotImplemented() = _$NotImplemented;
+}
+
+/// @nodoc
+abstract class $ServiceUnavailableCopyWith<$Res> {
+  factory $ServiceUnavailableCopyWith(
+          ServiceUnavailable value, $Res Function(ServiceUnavailable) then) =
+      _$ServiceUnavailableCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$ServiceUnavailableCopyWithImpl<$Res>
+    extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $ServiceUnavailableCopyWith<$Res> {
+  _$ServiceUnavailableCopyWithImpl(
+      ServiceUnavailable _value, $Res Function(ServiceUnavailable) _then)
+      : super(_value, (v) => _then(v as ServiceUnavailable));
+
+  @override
+  ServiceUnavailable get _value => super._value as ServiceUnavailable;
+}
+
+/// @nodoc
+class _$ServiceUnavailable implements ServiceUnavailable {
+  const _$ServiceUnavailable();
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.serviceUnavailable()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) || (other is ServiceUnavailable);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return serviceUnavailable();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (serviceUnavailable != null) {
+      return serviceUnavailable();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return serviceUnavailable(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (serviceUnavailable != null) {
+      return serviceUnavailable(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ServiceUnavailable implements NetworkExceptions {
+  const factory ServiceUnavailable() = _$ServiceUnavailable;
+}
+
+/// @nodoc
+abstract class $NoInternetConnectionCopyWith<$Res> {
+  factory $NoInternetConnectionCopyWith(NoInternetConnection value,
+          $Res Function(NoInternetConnection) then) =
+      _$NoInternetConnectionCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$NoInternetConnectionCopyWithImpl<$Res>
+    extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $NoInternetConnectionCopyWith<$Res> {
+  _$NoInternetConnectionCopyWithImpl(
+      NoInternetConnection _value, $Res Function(NoInternetConnection) _then)
+      : super(_value, (v) => _then(v as NoInternetConnection));
+
+  @override
+  NoInternetConnection get _value => super._value as NoInternetConnection;
+}
+
+/// @nodoc
+class _$NoInternetConnection implements NoInternetConnection {
+  const _$NoInternetConnection();
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.noInternetConnection()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) || (other is NoInternetConnection);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return noInternetConnection();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (noInternetConnection != null) {
+      return noInternetConnection();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return noInternetConnection(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (noInternetConnection != null) {
+      return noInternetConnection(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class NoInternetConnection implements NetworkExceptions {
+  const factory NoInternetConnection() = _$NoInternetConnection;
+}
+
+/// @nodoc
+abstract class $FormatExceptionCopyWith<$Res> {
+  factory $FormatExceptionCopyWith(
+          FormatException value, $Res Function(FormatException) then) =
+      _$FormatExceptionCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$FormatExceptionCopyWithImpl<$Res>
+    extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $FormatExceptionCopyWith<$Res> {
+  _$FormatExceptionCopyWithImpl(
+      FormatException _value, $Res Function(FormatException) _then)
+      : super(_value, (v) => _then(v as FormatException));
+
+  @override
+  FormatException get _value => super._value as FormatException;
+}
+
+/// @nodoc
+class _$FormatException implements FormatException {
+  const _$FormatException();
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.formatException()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) || (other is FormatException);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return formatException();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (formatException != null) {
+      return formatException();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return formatException(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (formatException != null) {
+      return formatException(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class FormatException implements NetworkExceptions {
+  const factory FormatException() = _$FormatException;
+}
+
+/// @nodoc
+abstract class $UnableToProcessCopyWith<$Res> {
+  factory $UnableToProcessCopyWith(
+          UnableToProcess value, $Res Function(UnableToProcess) then) =
+      _$UnableToProcessCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$UnableToProcessCopyWithImpl<$Res>
+    extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $UnableToProcessCopyWith<$Res> {
+  _$UnableToProcessCopyWithImpl(
+      UnableToProcess _value, $Res Function(UnableToProcess) _then)
+      : super(_value, (v) => _then(v as UnableToProcess));
+
+  @override
+  UnableToProcess get _value => super._value as UnableToProcess;
+}
+
+/// @nodoc
+class _$UnableToProcess implements UnableToProcess {
+  const _$UnableToProcess();
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.unableToProcess()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) || (other is UnableToProcess);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return unableToProcess();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (unableToProcess != null) {
+      return unableToProcess();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return unableToProcess(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (unableToProcess != null) {
+      return unableToProcess(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class UnableToProcess implements NetworkExceptions {
+  const factory UnableToProcess() = _$UnableToProcess;
+}
+
+/// @nodoc
+abstract class $DefaultErrorCopyWith<$Res> {
+  factory $DefaultErrorCopyWith(
+          DefaultError value, $Res Function(DefaultError) then) =
+      _$DefaultErrorCopyWithImpl<$Res>;
+
+  $Res call({String error});
+}
+
+/// @nodoc
+class _$DefaultErrorCopyWithImpl<$Res>
+    extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $DefaultErrorCopyWith<$Res> {
+  _$DefaultErrorCopyWithImpl(
+      DefaultError _value, $Res Function(DefaultError) _then)
+      : super(_value, (v) => _then(v as DefaultError));
+
+  @override
+  DefaultError get _value => super._value as DefaultError;
+
+  @override
+  $Res call({
+    Object error = freezed,
+  }) {
+    return _then(DefaultError(
+      error == freezed ? _value.error : error as String,
+    ));
+  }
+}
+
+/// @nodoc
+class _$DefaultError implements DefaultError {
+  const _$DefaultError(this.error) : assert(error != null);
+
+  @override
+  final String error;
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.defaultError(error: $error)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is DefaultError &&
+            (identical(other.error, error) ||
+                const DeepCollectionEquality().equals(other.error, error)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^ const DeepCollectionEquality().hash(error);
+
+  @JsonKey(ignore: true)
+  @override
+  $DefaultErrorCopyWith<DefaultError> get copyWith =>
+      _$DefaultErrorCopyWithImpl<DefaultError>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return defaultError(error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (defaultError != null) {
+      return defaultError(error);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return defaultError(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (defaultError != null) {
+      return defaultError(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class DefaultError implements NetworkExceptions {
+  const factory DefaultError(String error) = _$DefaultError;
+
+  String get error;
+
+  @JsonKey(ignore: true)
+  $DefaultErrorCopyWith<DefaultError> get copyWith;
+}
+
+/// @nodoc
+abstract class $UnexpectedErrorCopyWith<$Res> {
+  factory $UnexpectedErrorCopyWith(
+          UnexpectedError value, $Res Function(UnexpectedError) then) =
+      _$UnexpectedErrorCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$UnexpectedErrorCopyWithImpl<$Res>
+    extends _$NetworkExceptionsCopyWithImpl<$Res>
+    implements $UnexpectedErrorCopyWith<$Res> {
+  _$UnexpectedErrorCopyWithImpl(
+      UnexpectedError _value, $Res Function(UnexpectedError) _then)
+      : super(_value, (v) => _then(v as UnexpectedError));
+
+  @override
+  UnexpectedError get _value => super._value as UnexpectedError;
+}
+
+/// @nodoc
+class _$UnexpectedError implements UnexpectedError {
+  const _$UnexpectedError();
+
+  @override
+  String toString() {
+    return 'NetworkExceptions.unexpectedError()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) || (other is UnexpectedError);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult requestCancelled(),
+    @required TResult unauthorisedRequest(),
+    @required TResult badRequest(),
+    @required TResult notFound(String reason),
+    @required TResult methodNotAllowed(),
+    @required TResult notAcceptable(),
+    @required TResult requestTimeout(),
+    @required TResult sendTimeout(),
+    @required TResult conflict(),
+    @required TResult internalServerError(),
+    @required TResult notImplemented(),
+    @required TResult serviceUnavailable(),
+    @required TResult noInternetConnection(),
+    @required TResult formatException(),
+    @required TResult unableToProcess(),
+    @required TResult defaultError(String error),
+    @required TResult unexpectedError(),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return unexpectedError();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult requestCancelled(),
+    TResult unauthorisedRequest(),
+    TResult badRequest(),
+    TResult notFound(String reason),
+    TResult methodNotAllowed(),
+    TResult notAcceptable(),
+    TResult requestTimeout(),
+    TResult sendTimeout(),
+    TResult conflict(),
+    TResult internalServerError(),
+    TResult notImplemented(),
+    TResult serviceUnavailable(),
+    TResult noInternetConnection(),
+    TResult formatException(),
+    TResult unableToProcess(),
+    TResult defaultError(String error),
+    TResult unexpectedError(),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (unexpectedError != null) {
+      return unexpectedError();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult requestCancelled(RequestCancelled value),
+    @required TResult unauthorisedRequest(UnauthorisedRequest value),
+    @required TResult badRequest(BadRequest value),
+    @required TResult notFound(NotFound value),
+    @required TResult methodNotAllowed(MethodNotAllowed value),
+    @required TResult notAcceptable(NotAcceptable value),
+    @required TResult requestTimeout(RequestTimeout value),
+    @required TResult sendTimeout(SendTimeout value),
+    @required TResult conflict(Conflict value),
+    @required TResult internalServerError(InternalServerError value),
+    @required TResult notImplemented(NotImplemented value),
+    @required TResult serviceUnavailable(ServiceUnavailable value),
+    @required TResult noInternetConnection(NoInternetConnection value),
+    @required TResult formatException(FormatException value),
+    @required TResult unableToProcess(UnableToProcess value),
+    @required TResult defaultError(DefaultError value),
+    @required TResult unexpectedError(UnexpectedError value),
+  }) {
+    assert(requestCancelled != null);
+    assert(unauthorisedRequest != null);
+    assert(badRequest != null);
+    assert(notFound != null);
+    assert(methodNotAllowed != null);
+    assert(notAcceptable != null);
+    assert(requestTimeout != null);
+    assert(sendTimeout != null);
+    assert(conflict != null);
+    assert(internalServerError != null);
+    assert(notImplemented != null);
+    assert(serviceUnavailable != null);
+    assert(noInternetConnection != null);
+    assert(formatException != null);
+    assert(unableToProcess != null);
+    assert(defaultError != null);
+    assert(unexpectedError != null);
+    return unexpectedError(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult requestCancelled(RequestCancelled value),
+    TResult unauthorisedRequest(UnauthorisedRequest value),
+    TResult badRequest(BadRequest value),
+    TResult notFound(NotFound value),
+    TResult methodNotAllowed(MethodNotAllowed value),
+    TResult notAcceptable(NotAcceptable value),
+    TResult requestTimeout(RequestTimeout value),
+    TResult sendTimeout(SendTimeout value),
+    TResult conflict(Conflict value),
+    TResult internalServerError(InternalServerError value),
+    TResult notImplemented(NotImplemented value),
+    TResult serviceUnavailable(ServiceUnavailable value),
+    TResult noInternetConnection(NoInternetConnection value),
+    TResult formatException(FormatException value),
+    TResult unableToProcess(UnableToProcess value),
+    TResult defaultError(DefaultError value),
+    TResult unexpectedError(UnexpectedError value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (unexpectedError != null) {
+      return unexpectedError(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class UnexpectedError implements NetworkExceptions {
+  const factory UnexpectedError() = _$UnexpectedError;
+}

--- a/lib/models/auth_token.dart
+++ b/lib/models/auth_token.dart
@@ -1,0 +1,50 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'auth_token.g.dart';
+
+@JsonSerializable()
+class AuthToken {
+  @JsonKey(name: 'access_token')
+  String accessToken;
+  @JsonKey(name: 'token_type')
+  String tokenType;
+  @JsonKey(name: 'expires_in')
+  double expiresIn;
+  @JsonKey(name: 'refresh_token')
+  String refreshToken;
+
+  AuthToken(
+      {this.accessToken, this.tokenType, this.expiresIn, this.refreshToken});
+
+  factory AuthToken.fromJson(Map<String, dynamic> json) =>
+      _$AuthTokenFromJson(json);
+
+  Map<String, dynamic> toJson() => _$AuthTokenToJson(this);
+}
+
+@JsonSerializable()
+class InnerResponseData {
+  int id;
+  String type;
+  @JsonKey(name: 'attributes')
+  AuthToken authToken;
+
+  InnerResponseData({this.id, this.type, this.authToken});
+
+  factory InnerResponseData.fromJson(Map<String, dynamic> json) =>
+      _$InnerResponseDataFromJson(json);
+
+  Map<String, dynamic> toJson() => _$InnerResponseDataToJson(this);
+}
+
+@JsonSerializable()
+class AuthTokenResponseData {
+  InnerResponseData data;
+
+  AuthTokenResponseData({this.data});
+
+  factory AuthTokenResponseData.fromJson(Map<String, dynamic> json) =>
+      _$AuthTokenResponseDataFromJson(json);
+
+  Map<String, dynamic> toJson() => _$AuthTokenResponseDataToJson(this);
+}

--- a/lib/models/auth_token.g.dart
+++ b/lib/models/auth_token.g.dart
@@ -1,0 +1,55 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'auth_token.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+AuthToken _$AuthTokenFromJson(Map<String, dynamic> json) {
+  return AuthToken(
+    accessToken: json['access_token'] as String,
+    tokenType: json['token_type'] as String,
+    expiresIn: (json['expires_in'] as num)?.toDouble(),
+    refreshToken: json['refresh_token'] as String,
+  );
+}
+
+Map<String, dynamic> _$AuthTokenToJson(AuthToken instance) => <String, dynamic>{
+      'access_token': instance.accessToken,
+      'token_type': instance.tokenType,
+      'expires_in': instance.expiresIn,
+      'refresh_token': instance.refreshToken,
+    };
+
+InnerResponseData _$InnerResponseDataFromJson(Map<String, dynamic> json) {
+  return InnerResponseData(
+    id: json['id'] as int,
+    type: json['type'] as String,
+    authToken: json['attributes'] == null
+        ? null
+        : AuthToken.fromJson(json['attributes'] as Map<String, dynamic>),
+  );
+}
+
+Map<String, dynamic> _$InnerResponseDataToJson(InnerResponseData instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'attributes': instance.authToken,
+    };
+
+AuthTokenResponseData _$AuthTokenResponseDataFromJson(
+    Map<String, dynamic> json) {
+  return AuthTokenResponseData(
+    data: json['data'] == null
+        ? null
+        : InnerResponseData.fromJson(json['data'] as Map<String, dynamic>),
+  );
+}
+
+Map<String, dynamic> _$AuthTokenResponseDataToJson(
+        AuthTokenResponseData instance) =>
+    <String, dynamic>{
+      'data': instance.data,
+    };

--- a/lib/repositories/oauth_repository.dart
+++ b/lib/repositories/oauth_repository.dart
@@ -1,0 +1,25 @@
+import 'package:survey/api/api_client.dart';
+import 'package:survey/api/request/oauth_token_request.dart';
+import 'package:survey/flavors.dart';
+import 'package:survey/models/auth_token.dart';
+
+abstract class OAuthRepository {
+  Future<AuthToken> login(String email, String password);
+}
+
+class OAuthRepositoryImpl extends OAuthRepository {
+  ApiClient _restApiClient;
+
+  OAuthRepositoryImpl(this._restApiClient);
+
+  @override
+  Future<AuthToken> login(String email, String password) {
+    return _restApiClient
+        .login(OAuthTokenRequest(
+            email: email,
+            password: password,
+            clientId: F.basicAuthClientId,
+            clientSecret: F.basicAuthClientSecret))
+        .then((value) => value.data.authToken);
+  }
+}

--- a/lib/usecases/base_use_case.dart
+++ b/lib/usecases/base_use_case.dart
@@ -1,0 +1,17 @@
+part 'use_case_result.dart';
+
+abstract class BaseUseCase<T extends Result> {
+  const BaseUseCase();
+}
+
+abstract class UseCase<T, P> extends BaseUseCase<Result<T>> {
+  const UseCase() : super();
+
+  Future<Result<T>> call(P params);
+}
+
+abstract class NoParamsUseCase<T> extends BaseUseCase<Result<T>> {
+  const NoParamsUseCase() : super();
+
+  Future<Result<T>> call();
+}

--- a/lib/usecases/base_use_case.dart
+++ b/lib/usecases/base_use_case.dart
@@ -1,3 +1,5 @@
+import 'package:survey/exception/network_exceptions.dart';
+
 part 'use_case_result.dart';
 
 abstract class BaseUseCase<T extends Result> {

--- a/lib/usecases/login_use_case.dart
+++ b/lib/usecases/login_use_case.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/cupertino.dart';
 import 'package:survey/exception/network_exceptions.dart';
 import 'package:survey/models/auth_token.dart';
@@ -22,10 +24,11 @@ class LoginUseCase extends UseCase<AuthToken, LoginCredential> {
   Future<Result<AuthToken>> call(LoginCredential credential) async {
     try {
       final value =
-          await _repository.login(credential.email, credential.password);
+      await _repository.login(credential.email, credential.password);
       return Success(value);
     } catch (e) {
-      return Failed(NetworkExceptions.getDioException(e));
+      final apiError = ApiError(NetworkExceptions.getDioException(e), e);
+      return Future.value(Failed(apiError));
     }
   }
 }

--- a/lib/usecases/login_use_case.dart
+++ b/lib/usecases/login_use_case.dart
@@ -24,7 +24,7 @@ class LoginUseCase extends UseCase<AuthToken, LoginCredential> {
   Future<Result<AuthToken>> call(LoginCredential credential) async {
     try {
       final value =
-      await _repository.login(credential.email, credential.password);
+          await _repository.login(credential.email, credential.password);
       return Success(value);
     } catch (e) {
       final apiError = ApiError(NetworkExceptions.getDioException(e), e);

--- a/lib/usecases/login_use_case.dart
+++ b/lib/usecases/login_use_case.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/cupertino.dart';
+import 'package:survey/exception/network_exceptions.dart';
+import 'package:survey/models/auth_token.dart';
+import 'package:survey/repositories/oauth_repository.dart';
+import 'package:survey/usecases/base_use_case.dart';
+
+class LoginCredential {
+  @required
+  final String email;
+  @required
+  final String password;
+
+  LoginCredential(this.email, this.password);
+}
+
+class LoginUseCase extends UseCase<AuthToken, LoginCredential> {
+  final OAuthRepository _repository;
+
+  const LoginUseCase(this._repository);
+
+  @override
+  Future<Result<AuthToken>> call(LoginCredential credential) async {
+    try {
+      final value =
+          await _repository.login(credential.email, credential.password);
+      return Success(value);
+    } catch (e) {
+      return Failed(NetworkExceptions.getDioException(e));
+    }
+  }
+}

--- a/lib/usecases/use_case_result.dart
+++ b/lib/usecases/use_case_result.dart
@@ -1,0 +1,15 @@
+part of 'base_use_case.dart';
+
+abstract class Result<T> {}
+
+class Success<T> extends Result<T> {
+  final T value;
+
+  Success(this.value);
+}
+
+class Failed<E extends Exception> extends Result<E> {
+  final E error;
+
+  Failed(this.error);
+}

--- a/lib/usecases/use_case_result.dart
+++ b/lib/usecases/use_case_result.dart
@@ -8,8 +8,15 @@ class Success<T> extends Result<T> {
   Success(this.value);
 }
 
-class Failed<E extends Exception> extends Result<E> {
-  final E error;
+class ApiError implements Exception {
+  final NetworkExceptions networkExceptions;
+  final Exception actualException;
+
+  ApiError(this.networkExceptions, this.actualException);
+}
+
+class Failed<T> extends Result<T> {
+  final ApiError error;
 
   Failed(this.error);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "14.0.0"
+    version: "12.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.41.2"
+    version: "0.40.6"
   archive:
     dependency: transitive
     description:
@@ -49,14 +49,14 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.2"
+    version: "1.5.2"
   build_config:
     dependency: transitive
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.5"
+    version: "0.4.2"
   build_daemon:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.3"
+    version: "1.4.4"
   build_runner:
     dependency: "direct dev"
     description:
@@ -84,7 +84,7 @@ packages:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.7"
+    version: "6.0.3"
   built_collection:
     dependency: transitive
     description:
@@ -182,7 +182,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.12"
+    version: "1.3.10"
   dio:
     dependency: "direct main"
     description:
@@ -252,6 +252,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed:
+    dependency: "direct main"
+    description:
+      name: freezed
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.12.7"
+  freezed_annotation:
+    dependency: "direct main"
+    description:
+      name: freezed_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.12.0"
   fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
@@ -520,7 +534,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.10+3"
+    version: "0.9.7+1"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   retrofit: any
   logger: any
   json_annotation: ^3.1.1
+  freezed: ^0.12.7
+  freezed_annotation: ^0.12.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Closes #9

## What happened 👀

Implement API to login (/oauth/token).
 
## Insight 📝

- Add base_use_case; login_use_case;
- Add result returning from use_case to wrap around the response: either Success or Failed.
- Add OAuthRepository.
- Add model & corresponding parser
- Add HTTP Error handler & resolver (DioError).
 
## Proof Of Work 📹
Example of usage:

```
final dio = Dio()
      ..interceptors.add(LogInterceptor(requestBody: true, responseBody: true));
    final client = ApiClient(dio, baseUrl: F.restApiEndpoint);

    final authRepo = OAuthRepositoryImpl(client);
    final useCase = LoginUseCase(authRepo);

    useCase.call(LoginCredential('flutter@nimblehq.co', '12345678'));
```

On Success:
<img src="https://user-images.githubusercontent.com/13435717/112627158-cac8dd00-8e63-11eb-915f-053d7f57837f.png" width=400 />


On error (exception):
<img src="https://user-images.githubusercontent.com/13435717/112627174-d3211800-8e63-11eb-9701-9ea64cef95ec.png" width=400 />