### PR TITLE
#25 Add login_controller test

### DIFF
--- a/lib/pages/login/login_controller.dart
+++ b/lib/pages/login/login_controller.dart
@@ -9,25 +9,23 @@ class LoginController extends GetxController {
 
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
-  final formKey = GlobalKey<FormState>();
 
-  void attemptLogin({VoidCallback onSuccess, VoidCallback onFailed}) {
-    if (formKey.currentState.validate()) {
-      isLoading.value = true;
+  Future<void> attemptLogin(
+      {VoidCallback onSuccess, VoidCallback onFailed}) async {
+    isLoading.value = true;
 
-      final loginUseCase = Get.find<LoginUseCase>();
-      final credential = LoginCredential(
-          email: emailController.text, password: passwordController.text);
+    final loginUseCase = Get.find<LoginUseCase>();
+    final credential = LoginCredential(
+        email: emailController.text, password: passwordController.text);
 
-      loginUseCase.call(credential).then((result) {
-        if (result is Success) {
-          onSuccess.call();
-        } else {
-          isLoading.value = false;
-          onFailed.call();
-        }
-      });
-    }
+    loginUseCase.call(credential).then((result) {
+      if (result is Success && onSuccess != null) {
+        onSuccess.call();
+      } else {
+        isLoading.value = false;
+        if (onFailed != null) onFailed.call();
+      }
+    });
   }
 
   @override

--- a/lib/pages/login/login_page.dart
+++ b/lib/pages/login/login_page.dart
@@ -10,6 +10,8 @@ import 'package:survey/navigator/navigator.dart';
 import 'package:survey/pages/login/login_controller.dart';
 
 class LoginPage extends StatelessWidget {
+  final _formKey = GlobalKey<FormState>();
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -20,18 +22,18 @@ class LoginPage extends StatelessWidget {
             child: Container(
               decoration: BoxDecoration(
                 image: DecorationImage(
-                  fit: BoxFit.cover,
-                  image: AssetImage('assets/images/sign_in_background.png'),
-                  colorFilter: ColorFilter.mode(
-                      Colors.black.withOpacity(0.4), BlendMode.overlay),
-                ),
-              ),
-              child: BackdropFilter(
-                filter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
-                child: Padding(
-                  padding: const EdgeInsets.only(left: 24, right: 24),
-                  child: Form(
-                    key: controller.formKey,
+                      fit: BoxFit.cover,
+                      image: AssetImage('assets/images/sign_in_background.png'),
+                      colorFilter: ColorFilter.mode(
+                          Colors.black.withOpacity(0.4), BlendMode.overlay),
+                    ),
+                  ),
+                  child: BackdropFilter(
+                    filter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
+                    child: Padding(
+                      padding: const EdgeInsets.only(left: 24, right: 24),
+                      child: Form(
+                        key: _formKey,
                     autovalidateMode: AutovalidateMode.onUserInteraction,
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
@@ -43,36 +45,36 @@ class LoginPage extends StatelessWidget {
                         ),
                         const SizedBox(height: 100),
                         TextFormField(
-                          keyboardType: TextInputType.emailAddress,
-                          controller: controller.emailController,
-                          decoration: _formInputDecoration(
-                              label: AppLocalizations.of(context)
-                                  .titleGeneralEmail),
-                          style: TextStyle(color: Colors.white),
-                          validator: _emailValidator,
+                              keyboardType: TextInputType.emailAddress,
+                              controller: controller.emailController,
+                              decoration: _formInputDecoration(
+                                  label: AppLocalizations.of(context)
+                                      .titleGeneralEmail),
+                              style: TextStyle(color: Colors.white),
+                              validator: _emailValidator,
+                            ),
+                            const SizedBox(height: 20),
+                            TextFormField(
+                              keyboardType: TextInputType.text,
+                              controller: controller.passwordController,
+                              decoration: _formInputDecoration(
+                                  label: AppLocalizations.of(context)
+                                      .titleGeneralPassword),
+                              obscureText: true,
+                              style: TextStyle(color: Colors.white),
+                            ),
+                            const SizedBox(height: 50),
+                            GetX<LoginController>(builder: (state) {
+                              return _loginButton(
+                                  context: context, enable: !state.isLoading.value);
+                            }),
+                          ],
                         ),
-                        const SizedBox(height: 20),
-                        TextFormField(
-                          keyboardType: TextInputType.text,
-                          controller: controller.passwordController,
-                          decoration: _formInputDecoration(
-                              label: AppLocalizations.of(context)
-                                  .titleGeneralPassword),
-                          obscureText: true,
-                          style: TextStyle(color: Colors.white),
-                        ),
-                        const SizedBox(height: 50),
-                        GetX<LoginController>(builder: (state) {
-                          return _loginButton(
-                              context: context, enable: !state.isLoading.value);
-                        }),
-                      ],
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
-          ),
         ));
   }
 
@@ -81,12 +83,12 @@ class LoginPage extends StatelessWidget {
       style: enable
           ? ButtonStyle()
           : ButtonStyle(
-              backgroundColor: MaterialStateProperty.all<Color>(Colors.white24),
-              foregroundColor: MaterialStateProperty.all<Color>(Colors.white70),
-            ),
+        backgroundColor: MaterialStateProperty.all<Color>(Colors.white24),
+        foregroundColor: MaterialStateProperty.all<Color>(Colors.white70),
+      ),
       child: Text(AppLocalizations.of(context).buttonLogin),
       onPressed: () {
-        if (enable) {
+        if (enable && _formKey.currentState.validate()) {
           Get.focusScope.unfocus();
           return _attemptLogin();
         } else {
@@ -97,15 +99,15 @@ class LoginPage extends StatelessWidget {
   }
 
   InputDecoration _formInputDecoration({String label}) => InputDecoration(
-        labelStyle: TextStyle(color: Colors.white30),
-        floatingLabelBehavior: FloatingLabelBehavior.never,
-        border: OutlineInputBorder(
-            borderSide: BorderSide.none,
-            borderRadius: BorderRadius.circular(12.0)),
-        fillColor: Colors.white24,
-        filled: true,
-        labelText: label,
-      );
+    labelStyle: TextStyle(color: Colors.white30),
+    floatingLabelBehavior: FloatingLabelBehavior.never,
+    border: OutlineInputBorder(
+        borderSide: BorderSide.none,
+        borderRadius: BorderRadius.circular(12.0)),
+    fillColor: Colors.white24,
+    filled: true,
+    labelText: label,
+  );
 
   String _emailValidator(String value) {
     if (value == null || value.isEmpty) {

--- a/lib/pages/login/login_page.dart
+++ b/lib/pages/login/login_page.dart
@@ -22,18 +22,18 @@ class LoginPage extends StatelessWidget {
             child: Container(
               decoration: BoxDecoration(
                 image: DecorationImage(
-                      fit: BoxFit.cover,
-                      image: AssetImage('assets/images/sign_in_background.png'),
-                      colorFilter: ColorFilter.mode(
-                          Colors.black.withOpacity(0.4), BlendMode.overlay),
-                    ),
-                  ),
-                  child: BackdropFilter(
-                    filter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
-                    child: Padding(
-                      padding: const EdgeInsets.only(left: 24, right: 24),
-                      child: Form(
-                        key: _formKey,
+                  fit: BoxFit.cover,
+                  image: AssetImage('assets/images/sign_in_background.png'),
+                  colorFilter: ColorFilter.mode(
+                      Colors.black.withOpacity(0.4), BlendMode.overlay),
+                ),
+              ),
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
+                child: Padding(
+                  padding: const EdgeInsets.only(left: 24, right: 24),
+                  child: Form(
+                    key: _formKey,
                     autovalidateMode: AutovalidateMode.onUserInteraction,
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
@@ -45,36 +45,36 @@ class LoginPage extends StatelessWidget {
                         ),
                         const SizedBox(height: 100),
                         TextFormField(
-                              keyboardType: TextInputType.emailAddress,
-                              controller: controller.emailController,
-                              decoration: _formInputDecoration(
-                                  label: AppLocalizations.of(context)
-                                      .titleGeneralEmail),
-                              style: TextStyle(color: Colors.white),
-                              validator: _emailValidator,
-                            ),
-                            const SizedBox(height: 20),
-                            TextFormField(
-                              keyboardType: TextInputType.text,
-                              controller: controller.passwordController,
-                              decoration: _formInputDecoration(
-                                  label: AppLocalizations.of(context)
-                                      .titleGeneralPassword),
-                              obscureText: true,
-                              style: TextStyle(color: Colors.white),
-                            ),
-                            const SizedBox(height: 50),
-                            GetX<LoginController>(builder: (state) {
-                              return _loginButton(
-                                  context: context, enable: !state.isLoading.value);
-                            }),
-                          ],
+                          keyboardType: TextInputType.emailAddress,
+                          controller: controller.emailController,
+                          decoration: _formInputDecoration(
+                              label: AppLocalizations.of(context)
+                                  .titleGeneralEmail),
+                          style: TextStyle(color: Colors.white),
+                          validator: _emailValidator,
                         ),
-                      ),
+                        const SizedBox(height: 20),
+                        TextFormField(
+                          keyboardType: TextInputType.text,
+                          controller: controller.passwordController,
+                          decoration: _formInputDecoration(
+                              label: AppLocalizations.of(context)
+                                  .titleGeneralPassword),
+                          obscureText: true,
+                          style: TextStyle(color: Colors.white),
+                        ),
+                        const SizedBox(height: 50),
+                        GetX<LoginController>(builder: (state) {
+                          return _loginButton(
+                              context: context, enable: !state.isLoading.value);
+                        }),
+                      ],
                     ),
                   ),
                 ),
               ),
+            ),
+          ),
         ));
   }
 
@@ -83,9 +83,9 @@ class LoginPage extends StatelessWidget {
       style: enable
           ? ButtonStyle()
           : ButtonStyle(
-        backgroundColor: MaterialStateProperty.all<Color>(Colors.white24),
-        foregroundColor: MaterialStateProperty.all<Color>(Colors.white70),
-      ),
+              backgroundColor: MaterialStateProperty.all<Color>(Colors.white24),
+              foregroundColor: MaterialStateProperty.all<Color>(Colors.white70),
+            ),
       child: Text(AppLocalizations.of(context).buttonLogin),
       onPressed: () {
         if (enable && _formKey.currentState.validate()) {
@@ -99,15 +99,15 @@ class LoginPage extends StatelessWidget {
   }
 
   InputDecoration _formInputDecoration({String label}) => InputDecoration(
-    labelStyle: TextStyle(color: Colors.white30),
-    floatingLabelBehavior: FloatingLabelBehavior.never,
-    border: OutlineInputBorder(
-        borderSide: BorderSide.none,
-        borderRadius: BorderRadius.circular(12.0)),
-    fillColor: Colors.white24,
-    filled: true,
-    labelText: label,
-  );
+        labelStyle: TextStyle(color: Colors.white30),
+        floatingLabelBehavior: FloatingLabelBehavior.never,
+        border: OutlineInputBorder(
+            borderSide: BorderSide.none,
+            borderRadius: BorderRadius.circular(12.0)),
+        fillColor: Colors.white24,
+        filled: true,
+        labelText: label,
+      );
 
   String _emailValidator(String value) {
     if (value == null || value.isEmpty) {

--- a/test/pages/login/login_controller_test.dart
+++ b/test/pages/login/login_controller_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey/pages/login/login_controller.dart';
+import 'package:survey/use_cases/base_use_case.dart';
+import 'package:survey/use_cases/login_use_case.dart';
+
+import 'login_controller_test.mocks.dart';
+
+@GenerateMocks([LoginUseCase])
+void main() {
+  setUp(() {
+    Get.testMode = true;
+  });
+
+  group('Validate login controller login action', () {
+    final mockLoginUseCase = MockLoginUseCase();
+    final loginController = LoginController();
+    Get.lazyPut<LoginUseCase>(() => mockLoginUseCase);
+
+    loginController.emailController.text = 'hello';
+    loginController.passwordController.text = 'pwd';
+
+    test('When login with a valid credential, it calls onSuccess', () async {
+      var onSuccessCalled = false;
+
+      when(mockLoginUseCase.call(any)).thenAnswer((_) async => Success(null));
+
+      await loginController.attemptLogin(onSuccess: () {
+        onSuccessCalled = true;
+      });
+
+      expect(onSuccessCalled, true);
+      expect(loginController.isLoading.value, true);
+    });
+
+    test('When login with an invalid credential, it calls onFailed', () async {
+      var onFailedCalled = false;
+
+      when(mockLoginUseCase.call(any)).thenAnswer((_) async => Failed(null));
+
+      await loginController.attemptLogin(onFailed: () {
+        onFailedCalled = true;
+      });
+
+      expect(onFailedCalled, true);
+      expect(loginController.isLoading.value, false);
+    });
+  });
+}

--- a/test/pages/login/login_controller_test.mocks.dart
+++ b/test/pages/login/login_controller_test.mocks.dart
@@ -1,0 +1,11 @@
+import 'package:mockito/mockito.dart' as _i1;
+import 'package:survey/use_cases/login_use_case.dart' as _i2;
+
+/// A class which mocks [LoginUseCase].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockLoginUseCase extends _i1.Mock implements _i2.LoginUseCase {
+  MockLoginUseCase() {
+    _i1.throwOnMissingStub(this);
+  }
+}


### PR DESCRIPTION
## What happened 👀

Continue to write unit test for the login_controller.
 
## Insight 📝
Some changes need to be made: 
- Send the `_formKey` back to the View because it's an OS concrete component, we shouldn't include it in our business processor. It's very hard to control its behavior and hence testing is a huge problem.
- In `attempLogin()` contains async/await function, so to make it clear to the downstream usage, we should return a Future and mark with async; so when writing test or using the function, we can expect `await` to make sure the whole function ran properly before asserting. Otherwise, the result invoked via `onSuccess` will not arrive at the time we invoke the function synchronously.

Other than that, just some basic GetX insert dependency and testing with Mockito. 
 
## Proof Of Work 📹

Tests should pass.
