### PR TITLE
#43 Implement logged in state remember

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: 'stable' # 'dev', 'alpha', default to: 'stable'
-          # flutter-version: '1.12.x' # you can also specify exact version of flutter
+          flutter-version: '2.0.5'
 
       - name: Get flutter dependencies.
         run: flutter pub get

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:survey/navigator/navigator.dart';
 import 'package:survey/pages/home/home_page.dart';
 import 'package:survey/pages/login/login_binding.dart';
 import 'package:survey/pages/login/login_page.dart';
+import 'package:survey/pages/splash/splash_binding.dart';
 import 'package:survey/pages/splash/splash_page.dart';
 import 'package:survey/preferences/shared_preferences.dart';
 import 'package:survey/themes.dart';
@@ -29,8 +30,8 @@ class _AppState extends State<SurveyApp> {
     return GetMaterialApp(
       title: F.title,
       theme: appTheme,
-      home: SplashPage(),
       getPages: [
+        GetPage(name: "/", page: () => SplashPage(), binding: SplashBinding()),
         GetPage(
             name: "/login", page: () => LoginPage(), binding: LoginBinding()),
         GetPage(name: "/home", page: () => HomePage()),

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -8,7 +8,7 @@ class HomePage extends StatelessWidget {
     return Scaffold(
       body: Center(
         child: Text(
-          'Hello ${F.title}',
+          'Home Page ${F.title}',
         ),
       ),
     );

--- a/lib/pages/splash/splash_binding.dart
+++ b/lib/pages/splash/splash_binding.dart
@@ -1,0 +1,11 @@
+import 'package:get/get.dart';
+import 'package:survey/preferences/shared_preferences.dart';
+import 'package:survey/use_cases/get_login_state_use_case.dart';
+
+class SplashBinding implements Bindings {
+  @override
+  void dependencies() {
+    final sharedPref = Get.find<SharedPreferencesStorage>();
+    Get.put(GetLoginStateUseCase(sharedPref));
+  }
+}

--- a/lib/pages/splash/splash_controller.dart
+++ b/lib/pages/splash/splash_controller.dart
@@ -1,0 +1,22 @@
+import 'package:get/get.dart';
+import 'package:optional/optional.dart';
+import 'package:survey/use_cases/base_use_case.dart';
+import 'package:survey/use_cases/get_login_state_use_case.dart';
+
+class SplashController extends GetxController {
+  final Rx<Optional<bool>> isLoggedInUser = Optional<bool>.empty().obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+
+    final getLoginStateUseCase = Get.find<GetLoginStateUseCase>();
+    getLoginStateUseCase.call().then((result) {
+      if (result is Success) {
+        isLoggedInUser.value = Optional.of((result as Success).value);
+      } else {
+        isLoggedInUser.value = Optional.of(false);
+      }
+    });
+  }
+}

--- a/lib/pages/splash/splash_page.dart
+++ b/lib/pages/splash/splash_page.dart
@@ -3,25 +3,38 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get/get.dart';
 import 'package:survey/navigator/navigator.dart';
+import 'package:survey/pages/splash/splash_controller.dart';
 
 class SplashPage extends StatelessWidget {
   final AppNavigator _appNavigator = Get.find();
+  final splashController = Get.put(SplashController());
 
   @override
   Widget build(BuildContext context) {
     if (SchedulerBinding.instance.schedulerPhase == SchedulerPhase.idle) {
       SchedulerBinding.instance
-          .addPostFrameCallback((_) => _appNavigator.popAndNavigateToLogin());
+          .addPostFrameCallback((_) => _loginStatusCheck());
     }
     return Scaffold(
       body: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Text('Hello - Test splash - will rework later',
-              textAlign: TextAlign.center),
+          Text('Hello - Splash screen', textAlign: TextAlign.center),
         ],
       ),
     );
+  }
+
+  void _loginStatusCheck() {
+    Get.find<SplashController>().isLoggedInUser.stream.listen((isLoggedIn) {
+      if (isLoggedIn.isNotEmpty) {
+        if (isLoggedIn.value) {
+          _appNavigator.popAndNavigateToHome();
+        } else {
+          _appNavigator.popAndNavigateToLogin();
+        }
+      }
+    });
   }
 }

--- a/lib/use_cases/get_login_state_use_case.dart
+++ b/lib/use_cases/get_login_state_use_case.dart
@@ -1,0 +1,15 @@
+import 'package:survey/preferences/shared_preferences.dart';
+import 'package:survey/use_cases/base_use_case.dart';
+
+class GetLoginStateUseCase extends NoParamsUseCase<bool> {
+  final SharedPreferencesStorage _sharedPreferencesStorage;
+
+  const GetLoginStateUseCase(this._sharedPreferencesStorage);
+
+  @override
+  Future<Result<bool>> call() {
+    return _sharedPreferencesStorage
+        .getAccessToken()
+        .then((token) => Success(token != null && token.isNotEmpty));
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -409,6 +409,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.13"
+  optional:
+    dependency: "direct main"
+    description:
+      name: optional
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.0+1"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  optional: ^5.0.0+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Closes https://github.com/sleepylee/flutter-survey/issues/43

## What happened 👀

Implement a "Remember Logged in" like feature.
 
## Insight 📝
- Add a new UseCase to check the login state at the Splash. 
- If the user has logged in before a.k.a has an access token stored, then we send the user straight to the Home page instead of Login again. Send to login otherwise.
 
## Proof Of Work 📹
First time: send to Login
Second time: send to Home

https://user-images.githubusercontent.com/13435717/119654410-a2a12e80-be52-11eb-8ad6-580a8691631d.mp4