### PR TITLE
[Chore] Adding simple token validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ A survey conducting platform built with Flutter
 
     - `$ flutter pub run build_runner build --delete-conflicting-outputs`
 
+- Running unit testing:
+
+    - `$ flutter test test/directory/to/test` 
+
 ## License
 
 This project is Copyright (c) 2014 and onwards. It is free software,

--- a/lib/api/http/response/auth_token_response.dart
+++ b/lib/api/http/response/auth_token_response.dart
@@ -9,7 +9,7 @@ class AuthTokenResponse {
   @JsonKey(name: 'token_type')
   String tokenType;
   @JsonKey(name: 'expires_in')
-  double expiresIn;
+  int expiresIn;
   @JsonKey(name: 'refresh_token')
   String refreshToken;
 

--- a/lib/api/http/response/auth_token_response.g.dart
+++ b/lib/api/http/response/auth_token_response.g.dart
@@ -10,7 +10,7 @@ AuthTokenResponse _$AuthTokenResponseFromJson(Map<String, dynamic> json) {
   return AuthTokenResponse(
     accessToken: json['access_token'] as String,
     tokenType: json['token_type'] as String,
-    expiresIn: (json['expires_in'] as num)?.toDouble(),
+    expiresIn: json['expires_in'] as int,
     refreshToken: json['refresh_token'] as String,
   );
 }

--- a/lib/models/auth_token.dart
+++ b/lib/models/auth_token.dart
@@ -1,8 +1,8 @@
 class AuthToken {
-  var accessToken;
-  var refreshToken;
-  var tokenType;
-  var expiresIn;
+  String accessToken;
+  String refreshToken;
+  int expiresIn;
+  String tokenType;
 
   AuthToken(
       {this.accessToken, this.tokenType, this.expiresIn, this.refreshToken});

--- a/lib/preferences/shared_preferences.dart
+++ b/lib/preferences/shared_preferences.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 const String _PREF_KEY_TYPE = 'PREF_KEY_TYPE';
 const String _PREF_KEY_ACCESS_TOKEN = 'PREF_KEY_TOKEN';
 const String _PREF_KEY_REFRESH_TOKEN = 'PREF_KEY_REFRESH_TOKEN';
+const String _PREF_KEY_TOKEN_EXPIRATION = 'PREF_KEY_TOKEN_EXPIRATION';
 
 abstract class SharedPreferencesStorage {
   Future<String> getTokenType();
@@ -16,8 +17,13 @@ abstract class SharedPreferencesStorage {
   Future<String> getRefreshToken();
 
   Future<void> saveRefreshToken(String refreshToken);
+
+  Future<double> getTokenExpiration();
+
+  Future<void> saveTokenExpiration(double expiration);
 }
 
+// TODO: switch to secured_storage: https://pub.dev/packages/flutter_secure_storage
 class LocalSharedPreferencesStorage implements SharedPreferencesStorage {
   @override
   Future<void> saveTokenType(String tokenType) async {
@@ -53,5 +59,17 @@ class LocalSharedPreferencesStorage implements SharedPreferencesStorage {
   Future<void> saveRefreshToken(String refreshToken) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     return await prefs.setString(_PREF_KEY_REFRESH_TOKEN, refreshToken);
+  }
+
+  @override
+  Future<double> getTokenExpiration() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.getDouble(_PREF_KEY_TOKEN_EXPIRATION) ?? 0;
+  }
+
+  @override
+  Future<void> saveTokenExpiration(double expiration) async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    return await prefs.setDouble(_PREF_KEY_TOKEN_EXPIRATION, expiration);
   }
 }

--- a/lib/preferences/shared_preferences.dart
+++ b/lib/preferences/shared_preferences.dart
@@ -20,7 +20,7 @@ abstract class SharedPreferencesStorage {
 
   Future<double> getTokenExpiration();
 
-  Future<void> saveTokenExpiration(double expiration);
+  Future<void> saveTokenExpiration(int expiration);
 }
 
 // TODO: switch to secured_storage: https://pub.dev/packages/flutter_secure_storage
@@ -68,8 +68,8 @@ class LocalSharedPreferencesStorage implements SharedPreferencesStorage {
   }
 
   @override
-  Future<void> saveTokenExpiration(double expiration) async {
+  Future<void> saveTokenExpiration(int expiration) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    return await prefs.setDouble(_PREF_KEY_TOKEN_EXPIRATION, expiration);
+    return await prefs.setInt(_PREF_KEY_TOKEN_EXPIRATION, expiration);
   }
 }

--- a/lib/use_cases/get_login_state_use_case.dart
+++ b/lib/use_cases/get_login_state_use_case.dart
@@ -13,11 +13,15 @@ class GetLoginStateUseCase extends NoParamsUseCase<bool> {
   Future<Result<bool>> call() async {
     final token = await _sharedPreferencesStorage.getAccessToken();
     final tokenType = await _sharedPreferencesStorage.getTokenType();
-    final hasTokenStored = token != null && token.isNotEmpty;
-    if (hasTokenStored) {
+    final tokenExpiration =
+        await _sharedPreferencesStorage.getTokenExpiration();
+    final hasValidTokenStored = token != null &&
+        token.isNotEmpty &&
+        tokenExpiration > DateTime.now().millisecondsSinceEpoch;
+    if (hasValidTokenStored) {
       // TODO: create an Authenticator instead of calling directly like this
       _graphQLClientProvider.setAuthToken("$tokenType $token");
     }
-    return Success(hasTokenStored);
+    return Success(hasValidTokenStored);
   }
 }

--- a/lib/use_cases/login_use_case.dart
+++ b/lib/use_cases/login_use_case.dart
@@ -38,6 +38,8 @@ class LoginUseCase extends UseCase<void, LoginCredential> {
     _sharedPreferencesStorage.saveTokenType(data.tokenType);
     _sharedPreferencesStorage.saveAccessToken(data.accessToken);
     _sharedPreferencesStorage.saveRefreshToken(data.refreshToken);
+    _sharedPreferencesStorage.saveTokenExpiration(
+        data.expiresIn + DateTime.now().millisecondsSinceEpoch);
     // TODO: create an Authenticator instead of accessing directly like this
     _graphQLClientProvider
         .setAuthToken("${data.tokenType} ${data.accessToken}");

--- a/test/fakers/fake_shared_preferences_storage.dart
+++ b/test/fakers/fake_shared_preferences_storage.dart
@@ -18,6 +18,11 @@ class FakeSharedPreferencesStorage extends Fake
   }
 
   @override
+  Future<void> saveTokenExpiration(int expiration) async {
+    _fakeStorage['expires-in'] = expiration;
+  }
+
+  @override
   Future<void> saveRefreshToken(String refreshToken) async {
     _fakeStorage['refresh-token'] = refreshToken;
   }

--- a/test/use_cases/login_use_case_test.dart
+++ b/test/use_cases/login_use_case_test.dart
@@ -19,11 +19,13 @@ void main() {
     final mockStorage = FakeSharedPreferencesStorage();
     final mockGraphQLClientProvider = FakeGraphQLClientProvider();
 
-    when(mockRepository.login('positive', 'test')).thenAnswer((_) async =>
-        AuthToken(
-            accessToken: 'token',
-            tokenType: 'bearer',
-            refreshToken: 'refresh token'));
+    when(mockRepository.login('positive', 'test')).thenAnswer(
+      (_) async => AuthToken(
+          accessToken: 'token',
+          tokenType: 'bearer',
+          expiresIn: 5000,
+          refreshToken: 'refresh token'),
+    );
 
     when(mockRepository.login('negative', any)).thenAnswer((_) => Future.error(
         DioError(


### PR DESCRIPTION
## What happened 👀

Adding a simple token validator for now.
 
## Insight 📝
- Add expiration check when we fetch the token from the local storage.
- Add save/get methods for the expiration. Basically, when we get a token, we can update the expiration time == now() + expiresIn (millisec). Later we can retrieve & check with the current time.

- Moving forward, I will handle the refresh_token later with https://github.com/felangel/fresh/tree/master/packages/fresh_graphql
 
## Proof Of Work 📹
When the token is expired, it sends the users to log in. When the token is still valid, it sends the users to home like currently.
