### PR TITLE
[#19] Implement survey detail UI

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -19,6 +19,10 @@
   "@buttonLogin": {
     "description": "Label of the Login button"
   },
+  "buttonStartSurvey": "Start Survey",
+  "@buttonStartSurvey": {
+    "description": "Label of the Start Survey button"
+  },
   "errorValidationEmailEmpty": "Please enter your email",
   "@errorValidationEmailEmpty": {
     "description": "Error message when Email is empty"

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -4,6 +4,7 @@
   "titleToday": "วันนี้",
   "titleGeneralError": "ข้อผิดพลาด",
   "buttonLogin": "เข้าสู่ระบบ",
+  "buttonStartSurvey": "เริ่มการสำรวจ",
   "errorValidationEmailEmpty": "กรุณากรอกอีเมลของคุณ",
   "errorValidationEmailInvalid": "กรุณาใส่อีเมลที่ถูกต้อง",
   "errorLoginFailed": "เข้าสู่ระบบล้มเหลว! โปรดตรวจสอบอีเมลหรือรหัสผ่านของคุณอีกครั้ง"

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -4,6 +4,7 @@
   "titleToday": "Hôm Nay",
   "titleGeneralError": "Lỗi",
   "buttonLogin": "Đăng nhập",
+  "buttonStartSurvey": "Bắt đầu khảo sát",
   "errorValidationEmailEmpty": "Vui lòng nhập email",
   "errorValidationEmailInvalid": "Vui lòng nhập đúng email",
   "errorLoginFailed": "Lỗi đăng nhập! Vui lòng kiểm tra lại email và mật khẩu"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,8 @@ import 'package:survey/pages/login/login_binding.dart';
 import 'package:survey/pages/login/login_page.dart';
 import 'package:survey/pages/splash/splash_binding.dart';
 import 'package:survey/pages/splash/splash_page.dart';
+import 'package:survey/pages/survey/survey_binding.dart';
+import 'package:survey/pages/survey/survey_page.dart';
 import 'package:survey/preferences/shared_preferences.dart';
 import 'package:survey/themes.dart';
 
@@ -41,6 +43,10 @@ class _AppState extends State<SurveyApp> {
               name: "/login", page: () => LoginPage(), binding: LoginBinding()),
           GetPage(
               name: "/home", page: () => HomePage(), binding: HomeBinding()),
+          GetPage(
+              name: "/survey",
+              page: () => SurveyPage(),
+              binding: SurveyBinding()),
         ],
         localizationsDelegates: [
           AppLocalizations.delegate,

--- a/lib/navigator/const.dart
+++ b/lib/navigator/const.dart
@@ -1,0 +1,1 @@
+const String DATA_SURVEY_ID = "survey_id";

--- a/lib/navigator/navigator.dart
+++ b/lib/navigator/navigator.dart
@@ -1,9 +1,13 @@
 import 'package:get/get.dart';
 
+import 'const.dart';
+
 abstract class AppNavigator {
   void popAndNavigateToLogin();
 
   void popAndNavigateToHome();
+
+  void navigateToSurvey(String id);
 }
 
 class AppNavigatorImpl implements AppNavigator {
@@ -15,5 +19,10 @@ class AppNavigatorImpl implements AppNavigator {
   @override
   void popAndNavigateToHome() {
     Get.offAndToNamed('/home');
+  }
+
+  @override
+  void navigateToSurvey(String id) {
+    Get.toNamed('/survey', arguments: {DATA_SURVEY_ID: id});
   }
 }

--- a/lib/pages/home/survey_carousel/survey_carousel_card.dart
+++ b/lib/pages/home/survey_carousel/survey_carousel_card.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:get/get.dart';
+import 'package:survey/navigator/navigator.dart';
 import 'package:survey/pages/home/survey_carousel/survey_ui_model.dart';
 import 'package:survey/pages/ui/indicators_widget.dart';
 
@@ -62,7 +64,7 @@ class SurveyCarouselCard extends StatelessWidget {
                           ),
                           backgroundColor: Colors.white,
                           onPressed: () {
-                            // TODO: Add click action
+                            _navigateToSurveyDetail(surveyUiModel.id);
                           },
                         ),
                         flex: 1,
@@ -76,5 +78,10 @@ class SurveyCarouselCard extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  void _navigateToSurveyDetail(String id) {
+    final navigator = Get.find<AppNavigator>();
+    navigator.navigateToSurvey(id);
   }
 }

--- a/lib/pages/survey/survey_binding.dart
+++ b/lib/pages/survey/survey_binding.dart
@@ -1,0 +1,8 @@
+import 'package:get/get.dart';
+
+class SurveyBinding implements Bindings {
+  @override
+  void dependencies() {
+    // TODO: add DI binding
+  }
+}

--- a/lib/pages/survey/survey_page.dart
+++ b/lib/pages/survey/survey_page.dart
@@ -1,16 +1,87 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:get/get.dart';
 import 'package:survey/navigator/const.dart';
 
 class SurveyPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    // TODO: work on the UI:
+    final surveyId = Get.arguments[DATA_SURVEY_ID];
+
+    // TODO: work on the Integrated data later
     return Scaffold(
-        body: Center(
-      child: Text(
-          "Will fetch the survey detail id: ${Get.arguments[DATA_SURVEY_ID]}"),
-    ));
+      body: Stack(
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              image: DecorationImage(
+                image: NetworkImage(
+                    "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_l"),
+                fit: BoxFit.cover,
+                colorFilter: ColorFilter.mode(
+                    Colors.black.withOpacity(0.5), BlendMode.overlay),
+              ),
+            ),
+          ),
+          SafeArea(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                IconButton(
+                  icon: Icon(
+                    Icons.chevron_left,
+                    size: 40,
+                    color: Colors.white,
+                  ),
+                  onPressed: () {
+                    Get.back();
+                  },
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(20),
+                  child: Wrap(
+                    children: [
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            "Test Title, Test Title, Test Title, Test Title, Test Title, Test Title, Test Title, ",
+                            style: Theme.of(context).textTheme.headline4,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          Text(
+                            "Test Description, Test Description Test Description, Test Description Test Description, Test Description Test Description, Test Description Test Description, Test Description ",
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyText1
+                                .copyWith(color: Colors.white70, fontSize: 17),
+                            maxLines: 5,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+                      )
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Align(
+            alignment: Alignment.bottomRight,
+            child: ElevatedButton(
+              child: Padding(
+                padding: EdgeInsets.only(left: 20, right: 20, bottom: 5),
+                child: Text(AppLocalizations.of(context).buttonStartSurvey),
+              ),
+              onPressed: () {
+                // TODO: complete survey
+              },
+            ),
+          ).marginOnly(bottom: 50, right: 24),
+        ],
+      ),
+    );
   }
 }

--- a/lib/pages/survey/survey_page.dart
+++ b/lib/pages/survey/survey_page.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:survey/navigator/const.dart';
+
+class SurveyPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // TODO: work on the UI:
+    return Scaffold(
+        body: Center(
+      child: Text(
+          "Will fetch the survey detail id: ${Get.arguments[DATA_SURVEY_ID]}"),
+    ));
+  }
+}

--- a/lib/pages/survey/survey_page.dart
+++ b/lib/pages/survey/survey_page.dart
@@ -46,7 +46,7 @@ class SurveyPage extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Text(
-                            "Test Title, Test Title, Test Title, Test Title, Test Title, Test Title, Test Title, ",
+                            "Test $surveyId, Test Title, Test Title, Test Title, Test Title, Test Title, Test Title, ",
                             style: Theme.of(context).textTheme.headline4,
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,


### PR DESCRIPTION
Closes #19 

## What happened 👀

Implement the Survey Detail UI page.
 
## Insight 📝

- Added navigation from survey list to survey detail (passing survey_id).
- Added UI implementation for the Survey detail screen with some hardcoded value (background photo, title, description) 👉 will bind the data later.
 
## Proof Of Work 📹
<img src="https://user-images.githubusercontent.com/13435717/124094618-261df300-da83-11eb-8597-57975a217c2d.png" width=300 />


https://user-images.githubusercontent.com/13435717/124094537-10a8c900-da83-11eb-8515-dafbb8b22ed2.mp4

