### PR TITLE
[#21] Integrate survey detail to the UI

### DIFF
--- a/lib/api/graphql/query/surveys_query.dart
+++ b/lib/api/graphql/query/surveys_query.dart
@@ -20,6 +20,7 @@ const String GET_SURVEYS_QUERY = r"""
 const String GET_SURVEY_BY_ID = r"""
   query($surveyId: ID!){
     survey(id: $surveyId){
+      id
       title
       coverImageUrl
       description

--- a/lib/pages/login/login_page.dart
+++ b/lib/pages/login/login_page.dart
@@ -131,6 +131,7 @@ class LoginPage extends StatelessWidget {
         Get.snackbar(
           AppLocalizations.of(Get.context).titleGeneralError,
           AppLocalizations.of(Get.context).errorLoginFailed,
+          backgroundColor: Colors.white70,
         );
       },
     );

--- a/lib/pages/survey/survey_controller.dart
+++ b/lib/pages/survey/survey_controller.dart
@@ -1,8 +1,15 @@
 import 'package:get/get.dart';
+import 'package:optional/optional.dart';
+import 'package:survey/models/survey.dart';
 import 'package:survey/navigator/const.dart';
+import 'package:survey/use_cases/base_use_case.dart';
 import 'package:survey/use_cases/get_survey_detail_use_case.dart';
 
 class SurveyController extends GetxController {
+  final Rx<Optional<Survey>> _survey = Optional<Survey>.empty().obs;
+
+  Optional<Survey> get optionalSurvey => _survey.value;
+
   @override
   void onInit() {
     super.onInit();
@@ -10,6 +17,9 @@ class SurveyController extends GetxController {
     final surveyId = Get.arguments[DATA_SURVEY_ID];
     // TODO: remove this when integrate
     final getSurveyUseCase = Get.find<GetSurveyDetailUseCase>();
-    getSurveyUseCase.call(surveyId).then((value) => print("Value: $value"));
+    getSurveyUseCase.call(surveyId).then((result) => {
+          if (result is Success<Survey>)
+            {_survey.value = Optional.of(result.value)}
+        });
   }
 }

--- a/lib/pages/survey/survey_controller.dart
+++ b/lib/pages/survey/survey_controller.dart
@@ -21,9 +21,9 @@ class SurveyController extends GetxController {
     final getSurveyUseCase = Get.find<GetSurveyDetailUseCase>();
     getSurveyUseCase.call(surveyId).then((result) => {
           if (result is Success<Survey>)
-            {_survey.value = Optional.of(result.value)}
+            _survey.value = Optional.of(result.value)
           else
-            {print("Error when fetching survey, handle Error later.")}
+            print("Error when fetching survey, handle Error later.")
         });
   }
 }

--- a/lib/pages/survey/survey_controller.dart
+++ b/lib/pages/survey/survey_controller.dart
@@ -13,13 +13,17 @@ class SurveyController extends GetxController {
   @override
   void onInit() {
     super.onInit();
+    _getSurvey();
+  }
 
+  void _getSurvey() {
     final surveyId = Get.arguments[DATA_SURVEY_ID];
-    // TODO: remove this when integrate
     final getSurveyUseCase = Get.find<GetSurveyDetailUseCase>();
     getSurveyUseCase.call(surveyId).then((result) => {
           if (result is Success<Survey>)
             {_survey.value = Optional.of(result.value)}
+          else
+            {print("Error when fetching survey, handle Error later.")}
         });
   }
 }

--- a/lib/pages/survey/survey_page.dart
+++ b/lib/pages/survey/survey_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:get/get.dart';
+import 'package:survey/models/survey.dart';
 import 'package:survey/pages/survey/survey_controller.dart';
 
 class SurveyPage extends StatelessWidget {
@@ -15,7 +16,7 @@ class SurveyPage extends StatelessWidget {
         builder: (controller) => GetX<SurveyController>(
           builder: (state) {
             return state.optionalSurvey.isPresent
-                ? SurveyDetail(state: state)
+                ? SurveyDetail(survey: state.optionalSurvey.value)
                 // TODO: change this to the loading shimmer layout later
                 : ColoredBox(color: Colors.white12);
           },
@@ -26,9 +27,9 @@ class SurveyPage extends StatelessWidget {
 }
 
 class SurveyDetail extends StatelessWidget {
-  SurveyDetail({this.state});
+  SurveyDetail({this.survey});
 
-  final SurveyController state;
+  final Survey survey;
 
   @override
   Widget build(BuildContext context) {
@@ -37,7 +38,7 @@ class SurveyDetail extends StatelessWidget {
         Container(
           decoration: BoxDecoration(
             image: DecorationImage(
-              image: NetworkImage(state.optionalSurvey.value.hdCoverImageUrl),
+              image: NetworkImage(survey.hdCoverImageUrl),
               fit: BoxFit.cover,
               colorFilter: ColorFilter.mode(
                   Colors.black.withOpacity(0.5), BlendMode.overlay),
@@ -66,13 +67,13 @@ class SurveyDetail extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          state.optionalSurvey.value.title,
+                          survey.title,
                           style: Theme.of(context).textTheme.headline4,
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,
                         ),
                         Text(
-                          state.optionalSurvey.value.description,
+                          survey.description,
                           style: Theme.of(context)
                               .textTheme
                               .bodyText1
@@ -96,8 +97,7 @@ class SurveyDetail extends StatelessWidget {
               child: Text(AppLocalizations.of(context).buttonStartSurvey),
             ),
             onPressed: () {
-              Get.snackbar(
-                  "TODO", "Go to Survey: ${state.optionalSurvey.value.id}",
+              Get.snackbar("TODO", "Go to Survey: ${survey.id}",
                   backgroundColor: Colors.white70);
             },
           ),

--- a/lib/pages/survey/survey_page.dart
+++ b/lib/pages/survey/survey_page.dart
@@ -1,92 +1,108 @@
+import 'dart:ui';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:get/get.dart';
-import 'package:survey/navigator/const.dart';
 import 'package:survey/pages/survey/survey_controller.dart';
 
 class SurveyPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final surveyId = Get.arguments[DATA_SURVEY_ID];
-
-    // TODO: work on the Integrated data later
     return Scaffold(
       body: GetBuilder(
         init: SurveyController(),
-        builder: (controller) => Stack(
-          children: [
-            Container(
-              decoration: BoxDecoration(
-                image: DecorationImage(
-                  image: NetworkImage(
-                      "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_l"),
-                  fit: BoxFit.cover,
-                  colorFilter: ColorFilter.mode(
-                      Colors.black.withOpacity(0.5), BlendMode.overlay),
-                ),
-              ),
-            ),
-            SafeArea(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  IconButton(
-                    icon: Icon(
-                      Icons.chevron_left,
-                      size: 40,
-                      color: Colors.white,
-                    ),
-                    onPressed: () {
-                      Get.back();
-                    },
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(20),
-                    child: Wrap(
-                      children: [
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              "Test $surveyId, Test Title, Test Title, Test Title, Test Title, Test Title, Test Title, ",
-                              style: Theme.of(context).textTheme.headline4,
-                              maxLines: 2,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                            Text(
-                              "Test Description, Test Description Test Description, Test Description Test Description, Test Description Test Description, Test Description Test Description, Test Description ",
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .bodyText1
-                                  .copyWith(
-                                      color: Colors.white70, fontSize: 17),
-                              maxLines: 5,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ],
-                        )
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Align(
-              alignment: Alignment.bottomRight,
-              child: ElevatedButton(
-                child: Padding(
-                  padding: EdgeInsets.only(left: 20, right: 20, bottom: 5),
-                  child: Text(AppLocalizations.of(context).buttonStartSurvey),
-                ),
-                onPressed: () {
-                  // TODO: complete survey
-                },
-              ),
-            ).marginOnly(bottom: 50, right: 24),
-          ],
+        builder: (controller) => GetX<SurveyController>(
+          builder: (state) {
+            return state.optionalSurvey.isPresent
+                ? SurveyDetail(state: state)
+                // TODO: change this to the loading shimmer layout later
+                : ColoredBox(color: Colors.white12);
+          },
         ),
       ),
+    );
+  }
+}
+
+class SurveyDetail extends StatelessWidget {
+  SurveyDetail({this.state});
+
+  final SurveyController state;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Container(
+          decoration: BoxDecoration(
+            image: DecorationImage(
+              image: NetworkImage(state.optionalSurvey.value.hdCoverImageUrl),
+              fit: BoxFit.cover,
+              colorFilter: ColorFilter.mode(
+                  Colors.black.withOpacity(0.5), BlendMode.overlay),
+            ),
+          ),
+        ),
+        SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              IconButton(
+                icon: Icon(
+                  Icons.chevron_left,
+                  size: 40,
+                  color: Colors.white,
+                ),
+                onPressed: () {
+                  Get.back();
+                },
+              ),
+              Padding(
+                padding: const EdgeInsets.all(20),
+                child: Wrap(
+                  children: [
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          state.optionalSurvey.value.title,
+                          style: Theme.of(context).textTheme.headline4,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        Text(
+                          state.optionalSurvey.value.description,
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodyText1
+                              .copyWith(color: Colors.white70, fontSize: 17),
+                          maxLines: 5,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    )
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+        Align(
+          alignment: Alignment.bottomRight,
+          child: ElevatedButton(
+            child: Padding(
+              padding: EdgeInsets.only(left: 20, right: 20, bottom: 5),
+              child: Text(AppLocalizations.of(context).buttonStartSurvey),
+            ),
+            onPressed: () {
+              Get.snackbar(
+                  "TODO", "Go to Survey: ${state.optionalSurvey.value.id}",
+                  backgroundColor: Colors.white70);
+            },
+          ),
+        ).marginOnly(bottom: 50, right: 24),
+      ],
     );
   }
 }


### PR DESCRIPTION
Closes #21

## What happened 👀

Integrate the detail info a Survey to the Survey page after fetching the data from the graphql API on the last PR.
 
## Insight 📝
- Just binding data, update the holder, and prepare for the next integration (go to the question, show shimmer etc...)
 
## Proof Of Work 📹

https://user-images.githubusercontent.com/13435717/124589626-69fa6900-de84-11eb-95bc-099b2a082ab1.mov

