### PR TITLE
[Chore] Use CachedImage for a better performance

### DIFF
--- a/lib/pages/home/survey_carousel/survey_carousel_card.dart
+++ b/lib/pages/home/survey_carousel/survey_carousel_card.dart
@@ -17,7 +17,8 @@ class SurveyCarouselCard extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
           image: DecorationImage(
-            image: CachedNetworkImageProvider(surveyUiModel.imageUrl),
+        image: CachedNetworkImageProvider(surveyUiModel.imageUrl,
+            cacheKey: surveyUiModel.id),
         fit: BoxFit.cover,
         colorFilter:
             ColorFilter.mode(Colors.black.withOpacity(0.5), BlendMode.overlay),

--- a/lib/pages/home/survey_carousel/survey_carousel_card.dart
+++ b/lib/pages/home/survey_carousel/survey_carousel_card.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get/get.dart';
@@ -16,7 +17,7 @@ class SurveyCarouselCard extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
           image: DecorationImage(
-        image: NetworkImage(surveyUiModel.imageUrl),
+            image: CachedNetworkImageProvider(surveyUiModel.imageUrl),
         fit: BoxFit.cover,
         colorFilter:
             ColorFilter.mode(Colors.black.withOpacity(0.5), BlendMode.overlay),

--- a/lib/pages/survey/survey_page.dart
+++ b/lib/pages/survey/survey_page.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -38,7 +39,7 @@ class SurveyDetail extends StatelessWidget {
         Container(
           decoration: BoxDecoration(
             image: DecorationImage(
-              image: NetworkImage(survey.hdCoverImageUrl),
+              image: CachedNetworkImageProvider(survey.hdCoverImageUrl),
               fit: BoxFit.cover,
               colorFilter: ColorFilter.mode(
                   Colors.black.withOpacity(0.5), BlendMode.overlay),

--- a/lib/pages/survey/survey_page.dart
+++ b/lib/pages/survey/survey_page.dart
@@ -39,7 +39,8 @@ class SurveyDetail extends StatelessWidget {
         Container(
           decoration: BoxDecoration(
             image: DecorationImage(
-              image: CachedNetworkImageProvider(survey.hdCoverImageUrl),
+              image: CachedNetworkImageProvider(survey.hdCoverImageUrl,
+                  cacheKey: survey.id),
               fit: BoxFit.cover,
               colorFilter: ColorFilter.mode(
                   Colors.black.withOpacity(0.5), BlendMode.overlay),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -99,6 +99,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "7.1.0"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.5.1"
   characters:
     dependency: transitive
     description:
@@ -272,6 +279,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_blurhash:
+    dependency: transitive
+    description:
+      name: flutter_blurhash
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -451,6 +472,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.4"
+  image:
+    dependency: transitive
+    description:
+      name: image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.19"
   integration_test:
     dependency: "direct dev"
     description:
@@ -556,6 +584,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.7"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
   optional:
     dependency: "direct main"
     description:
@@ -925,6 +960,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.2"
   uuid_enhanced:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   optional: ^5.0.0+1
+  cached_network_image: ^2.5.1
 
   graphql_flutter: ^4.0.1
 


### PR DESCRIPTION
## What happened 👀

An improvement PR to use cached image in order to improve the performance of reloading the same HD images of each survey, coming from the Survey list these should have been loaded and cached properly before.
 
## Insight 📝

- Use cached_network_image package: https://pub.dev/packages/cached_network_image
 
## Proof Of Work 📹

It loads instantly, the white loading screen is because we were fetching the Survey in the background


https://user-images.githubusercontent.com/13435717/124721561-6bcf3580-df33-11eb-9aa5-bfda4dad60b5.mp4



