### PR TITLE
[#76] [UI] Create selector picker for choice and dropdown [Part 2]

### DIFF
--- a/lib/pages/survey/survey_answer.dart
+++ b/lib/pages/survey/survey_answer.dart
@@ -1,27 +1,33 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:survey/pages/ui/picker_selector.dart';
 import 'package:survey/pages/ui/slide_rating_bar.dart';
 
 class SurveyAnswer extends StatelessWidget {
   final String type;
+  final List<String> optionsText;
   final int questionIndex;
   final int counter;
 
-  SurveyAnswer({this.type, this.questionIndex = 0, this.counter = -1});
+  SurveyAnswer(
+      {this.type, this.optionsText, this.questionIndex = 0, this.counter = -1});
 
   @override
   Widget build(BuildContext context) {
-    return _processAnswerUi(type, counter);
+    return _processAnswerUi(type, optionsText, counter);
   }
 }
 
-Widget _processAnswerUi(String type, int counter) {
+Widget _processAnswerUi(String type, List<String> optionsText, int counter) {
   switch (type) {
     case RATING_TYPE_STAR:
     case RATING_TYPE_HEART:
     case RATING_TYPE_SLIDER:
     case RATING_TYPE_MONEY:
       return SlideRatingBar.from(type, counter);
+    case RATING_TYPE_CHOICE:
+    case RATING_TYPE_DROPDOWN:
+      return PickerSelector(optionsText: optionsText);
     default:
       return SizedBox.shrink();
   }

--- a/lib/pages/survey/survey_question_page.dart
+++ b/lib/pages/survey/survey_question_page.dart
@@ -77,22 +77,10 @@ class SurveyQuestionPage extends StatelessWidget {
               ),
             ),
             // TODO: remove these:
-            Align(
-              alignment: Alignment.center,
-              child: SurveyAnswer(type: "heart"),
-            ),
-            Align(
-              alignment: Alignment.center,
-              child: SurveyAnswer(type: "star"),
+            SurveyAnswer(
+              type: "choice", // TODO: Come from API
+              optionsText: ["Yes", "No", "Ok"],
             ).marginOnly(top: 85),
-            Align(
-              alignment: Alignment.center,
-              child: SurveyAnswer(type: "money"),
-            ).marginOnly(top: 165),
-            Align(
-              alignment: Alignment.center,
-              child: SurveyAnswer(type: "slider"),
-            ).marginOnly(top: 235),
             Align(
               alignment: Alignment.bottomRight,
               child: FloatingActionButton(

--- a/lib/pages/ui/picker_selector.dart
+++ b/lib/pages/ui/picker_selector.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+const double ITEM_SIZE = 50.0;
+
+const String RATING_TYPE_CHOICE = "choice";
+const String RATING_TYPE_DROPDOWN = "dropdown";
+
+class PickerSelector extends StatelessWidget {
+  final List<String> optionsText;
+
+  PickerSelector({@required this.optionsText});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SizedBox(
+        height: 150,
+        child: CupertinoPicker(
+          itemExtent: ITEM_SIZE,
+          selectionOverlay: CustomPaint(painter: TwoHorizontalLinesPainter()),
+          children: _getOptionWidgets(context, optionsText),
+          onSelectedItemChanged: (index) {
+            // TODO: update this behavior to ViewModel
+            print("Selected: $index");
+          },
+        ),
+      ),
+    );
+  }
+}
+
+List<Widget> _getOptionWidgets(BuildContext context, List<String> options) {
+  final optionStyle = Theme.of(context)
+      .textTheme
+      .subtitle1
+      .copyWith(color: Colors.white, fontSize: 20);
+
+  return options
+      .map((item) => Center(child: Text(item, style: optionStyle)))
+      .toList();
+}
+
+// Drawing only the 2 horizontal line of a rectangle
+class TwoHorizontalLinesPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.drawLine(
+      Offset(80.0, 0.0),
+      Offset(320, 0.0),
+      Paint()..color = Colors.white,
+    );
+
+    canvas.drawLine(
+      Offset(80.0, ITEM_SIZE),
+      Offset(320, ITEM_SIZE),
+      Paint()..color = Colors.white,
+    );
+  }
+
+  @override
+  bool shouldRepaint(TwoHorizontalLinesPainter oldDelegate) {
+    return false;
+  }
+}


### PR DESCRIPTION
Part of #76 

## What happened 👀

Prepare the Answer UI for type `choice` and `dropdown`. Since we are not having multiple choices, I'm using the same UI for these 2 now.
 
## Insight 📝
- Use `CupertinoPicker`
- Customize the Drawer on the selected item.
 
## Proof Of Work 📹

<img src="https://user-images.githubusercontent.com/13435717/124908418-7d880a00-e013-11eb-9fae-b617dad33b8d.png" width=350 />

