### PR TITLE
[#76] Use listView instead of Column to avoid covered UI

### DIFF
--- a/lib/pages/survey/survey_question_page.dart
+++ b/lib/pages/survey/survey_question_page.dart
@@ -85,7 +85,8 @@ class SurveyQuestionPage extends StatelessWidget {
                 optionsText: [
                   "First Name",
                   "Last Name",
-                  "Age"
+                  "Age",
+                  "More",
                 ], // TODO: Come from API
               ),
             ),

--- a/lib/pages/ui/text_field_rating.dart
+++ b/lib/pages/ui/text_field_rating.dart
@@ -11,12 +11,17 @@ class TextFieldRating extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
+      height: 300,
+      alignment: Alignment.topCenter,
       child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 24),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: _makeTextFields(context, hints),
+        padding: EdgeInsets.symmetric(horizontal: 24, vertical: 10),
+        child: MediaQuery.removePadding(
+          context: context,
+          removeTop: true,
+          child: ListView(
+            scrollDirection: Axis.vertical,
+            children: _makeTextFields(context, hints),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Part of #76 

## What happened 👀

Small adjustments, use a list view to host the input text fields instead of the normal Column, because if the list is long, the keyboard will cover the form and it will not be scrollable.
 
## Insight 📝

- Change from Column -> ListView.
 
## Proof Of Work 📹

All fields are accessible when there are more than 3 fields:

https://user-images.githubusercontent.com/13435717/125411640-50a76e80-e3e8-11eb-971b-c3b9fec40b36.mp4

