### PR TITLE
[#77] Mapping questions and answers backend data [Part 1]

### DIFF
--- a/lib/api/graphql/query/surveys_query.dart
+++ b/lib/api/graphql/query/surveys_query.dart
@@ -11,7 +11,7 @@ const String GET_SURVEYS_QUERY = r"""
           questions {
             id,
             text,
-            imageUrl,
+            coverImageUrl,
             displayType,
             isMandatory
             answers {
@@ -39,7 +39,7 @@ const String GET_SURVEY_BY_ID = r"""
       questions {
         id,
         text,
-        imageUrl,
+        coverImageUrl,
         displayType,
         isMandatory
         answers {

--- a/lib/api/graphql/query/surveys_query.dart
+++ b/lib/api/graphql/query/surveys_query.dart
@@ -8,6 +8,18 @@ const String GET_SURVEYS_QUERY = r"""
           title
           coverImageUrl
           description
+          questions {
+            id,
+            text,
+            imageUrl,
+            displayType,
+            isMandatory
+            answers {
+              id
+              text
+              score
+            }
+          }
         }
       }
       pageInfo {
@@ -27,10 +39,11 @@ const String GET_SURVEY_BY_ID = r"""
       questions {
         id,
         text,
+        imageUrl,
         displayType,
-        displayOrder,
-        coverImageUrl,
+        isMandatory
         answers {
+          id
           text
           score
         }

--- a/lib/api/graphql/response/survey_response.dart
+++ b/lib/api/graphql/response/survey_response.dart
@@ -33,11 +33,58 @@ class SurveyResponse {
   String title;
   String coverImageUrl;
   String description;
+  @JsonKey(name: "questions")
+  List<SurveyQuestionResponse> surveyQuestionResponses;
 
-  SurveyResponse({this.id, this.title, this.coverImageUrl, this.description});
+  SurveyResponse({
+    this.id,
+    this.title,
+    this.coverImageUrl,
+    this.description,
+    this.surveyQuestionResponses,
+  });
 
   factory SurveyResponse.fromJson(Map<String, dynamic> json) =>
       _$SurveyResponseFromJson(json);
 
   Map<String, dynamic> toJson() => _$SurveyResponseToJson(this);
+}
+
+@JsonSerializable()
+class SurveyQuestionResponse {
+  String id;
+  String text;
+  String imageUrl;
+  String displayType;
+  bool isMandatory;
+  @JsonKey(name: "answers")
+  List<SurveyAnswerResponse> surveyAnswerResponses;
+
+  SurveyQuestionResponse({
+    this.id,
+    this.text,
+    this.imageUrl,
+    this.displayType,
+    this.isMandatory,
+    this.surveyAnswerResponses,
+  });
+
+  factory SurveyQuestionResponse.fromJson(Map<String, dynamic> json) =>
+      _$SurveyQuestionResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SurveyQuestionResponseToJson(this);
+}
+
+@JsonSerializable()
+class SurveyAnswerResponse {
+  String id;
+  String text;
+  int score;
+
+  SurveyAnswerResponse({this.id, this.text, this.score});
+
+  factory SurveyAnswerResponse.fromJson(Map<String, dynamic> json) =>
+      _$SurveyAnswerResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SurveyAnswerResponseToJson(this);
 }

--- a/lib/api/graphql/response/survey_response.dart
+++ b/lib/api/graphql/response/survey_response.dart
@@ -54,7 +54,7 @@ class SurveyResponse {
 class SurveyQuestionResponse {
   String id;
   String text;
-  String imageUrl;
+  String coverImageUrl;
   String displayType;
   bool isMandatory;
   @JsonKey(name: "answers")
@@ -63,7 +63,7 @@ class SurveyQuestionResponse {
   SurveyQuestionResponse({
     this.id,
     this.text,
-    this.imageUrl,
+    this.coverImageUrl,
     this.displayType,
     this.isMandatory,
     this.surveyAnswerResponses,

--- a/lib/api/graphql/response/survey_response.g.dart
+++ b/lib/api/graphql/response/survey_response.g.dart
@@ -42,6 +42,11 @@ SurveyResponse _$SurveyResponseFromJson(Map<String, dynamic> json) {
     title: json['title'] as String,
     coverImageUrl: json['coverImageUrl'] as String,
     description: json['description'] as String,
+    surveyQuestionResponses: (json['questions'] as List)
+        ?.map((e) => e == null
+            ? null
+            : SurveyQuestionResponse.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
   );
 }
 
@@ -51,4 +56,48 @@ Map<String, dynamic> _$SurveyResponseToJson(SurveyResponse instance) =>
       'title': instance.title,
       'coverImageUrl': instance.coverImageUrl,
       'description': instance.description,
+      'questions': instance.surveyQuestionResponses,
+    };
+
+SurveyQuestionResponse _$SurveyQuestionResponseFromJson(
+    Map<String, dynamic> json) {
+  return SurveyQuestionResponse(
+    id: json['id'] as String,
+    text: json['text'] as String,
+    imageUrl: json['imageUrl'] as String,
+    displayType: json['displayType'] as String,
+    isMandatory: json['isMandatory'] as bool,
+    surveyAnswerResponses: (json['answers'] as List)
+        ?.map((e) => e == null
+            ? null
+            : SurveyAnswerResponse.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+  );
+}
+
+Map<String, dynamic> _$SurveyQuestionResponseToJson(
+        SurveyQuestionResponse instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'text': instance.text,
+      'imageUrl': instance.imageUrl,
+      'displayType': instance.displayType,
+      'isMandatory': instance.isMandatory,
+      'answers': instance.surveyAnswerResponses,
+    };
+
+SurveyAnswerResponse _$SurveyAnswerResponseFromJson(Map<String, dynamic> json) {
+  return SurveyAnswerResponse(
+    id: json['id'] as String,
+    text: json['text'] as String,
+    score: json['score'] as int,
+  );
+}
+
+Map<String, dynamic> _$SurveyAnswerResponseToJson(
+        SurveyAnswerResponse instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'text': instance.text,
+      'score': instance.score,
     };

--- a/lib/api/graphql/response/survey_response.g.dart
+++ b/lib/api/graphql/response/survey_response.g.dart
@@ -64,7 +64,7 @@ SurveyQuestionResponse _$SurveyQuestionResponseFromJson(
   return SurveyQuestionResponse(
     id: json['id'] as String,
     text: json['text'] as String,
-    imageUrl: json['imageUrl'] as String,
+    coverImageUrl: json['coverImageUrl'] as String,
     displayType: json['displayType'] as String,
     isMandatory: json['isMandatory'] as bool,
     surveyAnswerResponses: (json['answers'] as List)
@@ -80,7 +80,7 @@ Map<String, dynamic> _$SurveyQuestionResponseToJson(
     <String, dynamic>{
       'id': instance.id,
       'text': instance.text,
-      'imageUrl': instance.imageUrl,
+      'coverImageUrl': instance.coverImageUrl,
       'displayType': instance.displayType,
       'isMandatory': instance.isMandatory,
       'answers': instance.surveyAnswerResponses,

--- a/lib/gen/assets.gen.dart
+++ b/lib/gen/assets.gen.dart
@@ -3,6 +3,7 @@
 /// *****************************************************
 ///  FlutterGen
 /// *****************************************************
+
 import 'package:flutter/widgets.dart';
 
 class $AssetsImagesGen {

--- a/lib/mappers/survey_mapper.dart
+++ b/lib/mappers/survey_mapper.dart
@@ -28,7 +28,7 @@ extension QuestionResponseMapper on List<SurveyQuestionResponse> {
   List<SurveyQuestion> toSurveyQuestions() {
     return map((question) => SurveyQuestion(
           id: question.id,
-          imageUrl: question.imageUrl,
+          coverImageUrl: question.coverImageUrl,
           displayType: question.displayType,
           text: question.text,
           isMandatory: question.isMandatory,

--- a/lib/mappers/survey_mapper.dart
+++ b/lib/mappers/survey_mapper.dart
@@ -1,0 +1,48 @@
+import 'package:survey/api/graphql/response/survey_response.dart';
+import 'package:survey/models/survey.dart';
+
+extension SurveyNodeMapper on SurveyNodeResponse {
+  Survey toSurvey() {
+    return Survey(
+        cursor: this.cursor,
+        id: this.node.id,
+        title: this.node.title,
+        description: this.node.description,
+        coverImageUrl: this.node.coverImageUrl,
+        questions: this.node.surveyQuestionResponses.toSurveyQuestions());
+  }
+}
+
+extension SurveyResponseMapper on SurveyResponse {
+  Survey toSurvey() {
+    return Survey(
+        id: this.id,
+        title: this.title,
+        description: this.description,
+        coverImageUrl: this.coverImageUrl,
+        questions: this.surveyQuestionResponses.toSurveyQuestions());
+  }
+}
+
+extension QuestionResponseMapper on List<SurveyQuestionResponse> {
+  List<SurveyQuestion> toSurveyQuestions() {
+    return map((question) => SurveyQuestion(
+          id: question.id,
+          imageUrl: question.imageUrl,
+          displayType: question.displayType,
+          text: question.text,
+          isMandatory: question.isMandatory,
+          answers: question.surveyAnswerResponses.toSurveyAnswers(),
+        )).toList();
+  }
+}
+
+extension AnswerResponseMapper on List<SurveyAnswerResponse> {
+  List<SurveyAnswer> toSurveyAnswers() {
+    return map((answer) => SurveyAnswer(
+          id: answer.id,
+          text: answer.text,
+          score: answer.score,
+        )).toList();
+  }
+}

--- a/lib/models/survey.dart
+++ b/lib/models/survey.dart
@@ -20,7 +20,7 @@ class Survey {
 class SurveyQuestion {
   String id;
   String text;
-  String imageUrl;
+  String coverImageUrl;
   String displayType;
   bool isMandatory;
   List<SurveyAnswer> answers;
@@ -28,10 +28,12 @@ class SurveyQuestion {
   SurveyQuestion(
       {this.id,
       this.text,
-      this.imageUrl,
+      this.coverImageUrl,
       this.displayType,
       this.isMandatory,
       this.answers});
+
+  String get hdCoverImageUrl => coverImageUrl + "l";
 }
 
 class SurveyAnswer {

--- a/lib/models/survey.dart
+++ b/lib/models/survey.dart
@@ -4,9 +4,40 @@ class Survey {
   String title;
   String description;
   String coverImageUrl;
+  List<SurveyQuestion> questions;
 
   Survey(
-      {this.cursor, this.id, this.title, this.description, this.coverImageUrl});
+      {this.cursor,
+      this.id,
+      this.title,
+      this.description,
+      this.coverImageUrl,
+      this.questions});
 
   String get hdCoverImageUrl => coverImageUrl + "l";
+}
+
+class SurveyQuestion {
+  String id;
+  String text;
+  String imageUrl;
+  String displayType;
+  bool isMandatory;
+  List<SurveyAnswer> answers;
+
+  SurveyQuestion(
+      {this.id,
+      this.text,
+      this.imageUrl,
+      this.displayType,
+      this.isMandatory,
+      this.answers});
+}
+
+class SurveyAnswer {
+  String id;
+  String text;
+  int score;
+
+  SurveyAnswer({this.id, this.text, this.score});
 }

--- a/lib/repositories/survey_repository.dart
+++ b/lib/repositories/survey_repository.dart
@@ -25,15 +25,7 @@ class SurveyRepositoryImpl implements SurveyRepository {
     return _graphQlClient.query(queryOptions).then((value) {
       if (value.data != null) {
         final surveysResponse = SurveysResponse.fromJson(value.data['surveys']);
-
-        final surveysList = <Survey>[];
-
-        surveysResponse.edges.forEach((item) {
-          final surveyItem = item.toSurvey();
-          surveysList.add(surveyItem);
-        });
-
-        return surveysList;
+        return surveysResponse.edges.map((item) => item.toSurvey()).toList();
       } else {
         throw NetworkExceptions.notFound("Something is wrong");
       }

--- a/lib/repositories/survey_repository.dart
+++ b/lib/repositories/survey_repository.dart
@@ -43,7 +43,7 @@ class SurveyRepositoryImpl implements SurveyRepository {
   @override
   Future<Survey> getSurveyById(String id) {
     final queryOptions = QueryOptions(
-        fetchPolicy: FetchPolicy.networkOnly,
+        fetchPolicy: FetchPolicy.cacheAndNetwork,
         document: gql(GET_SURVEY_BY_ID),
         variables: {'surveyId': id});
     return _graphQlClient.query(queryOptions).then((value) {

--- a/lib/repositories/survey_repository.dart
+++ b/lib/repositories/survey_repository.dart
@@ -2,6 +2,7 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:survey/api/graphql/query/surveys_query.dart';
 import 'package:survey/api/graphql/response/survey_response.dart';
 import 'package:survey/exception/network_exceptions.dart';
+import 'package:survey/mappers/survey_mapper.dart';
 import 'package:survey/models/survey.dart';
 
 abstract class SurveyRepository {
@@ -28,13 +29,7 @@ class SurveyRepositoryImpl implements SurveyRepository {
         final surveysList = <Survey>[];
 
         surveysResponse.edges.forEach((item) {
-          final surveyItem = Survey(
-            cursor: item.cursor,
-            id: item.node.id,
-            title: item.node.title,
-            description: item.node.description,
-            coverImageUrl: item.node.coverImageUrl,
-          );
+          final surveyItem = item.toSurvey();
           surveysList.add(surveyItem);
         });
 
@@ -48,17 +43,13 @@ class SurveyRepositoryImpl implements SurveyRepository {
   @override
   Future<Survey> getSurveyById(String id) {
     final queryOptions = QueryOptions(
-        fetchPolicy: FetchPolicy.cacheAndNetwork,
+        fetchPolicy: FetchPolicy.networkOnly,
         document: gql(GET_SURVEY_BY_ID),
         variables: {'surveyId': id});
     return _graphQlClient.query(queryOptions).then((value) {
       if (value.data != null) {
         final surveyResponse = SurveyResponse.fromJson(value.data['survey']);
-        return Survey(
-            id: surveyResponse.id,
-            title: surveyResponse.title,
-            description: surveyResponse.description,
-            coverImageUrl: surveyResponse.coverImageUrl);
+        return surveyResponse.toSurvey();
       } else {
         throw NetworkExceptions.notFound("Something is wrong");
       }


### PR DESCRIPTION
Part of #77 

## What happened 👀

Mapping the questions and answers of a survey from the graphql response and exchange to the app models.
 
## Insight 📝

- Simply add extra fields for the application to use later.
- Add & correct fields from graphql query
- Create extensions for all mapping purposes.
 
## Proof Of Work 📹

The app should work normally; actually I already used data for the [Integrate] part on the next PR so this PR should be reviewed separately and work as expected.
