### PR TITLE
[#91] Add mutation to createResponse

### DIFF
--- a/lib/api/graphql/mutation/create_response_mutation_input.dart
+++ b/lib/api/graphql/mutation/create_response_mutation_input.dart
@@ -1,0 +1,54 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'create_response_mutation_input.g.dart';
+
+@JsonSerializable()
+class CreateResponseMutationInput {
+  CreateResponseMutationInput(this.response);
+
+  SurveySubmission response;
+
+  factory CreateResponseMutationInput.fromJson(Map<String, dynamic> json) =>
+      _$CreateResponseMutationInputFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CreateResponseMutationInputToJson(this);
+}
+
+@JsonSerializable()
+class SurveySubmission {
+  String surveyId;
+  List<SurveyQuestionSubmission> questions;
+
+  SurveySubmission(this.surveyId, this.questions);
+
+  factory SurveySubmission.fromJson(Map<String, dynamic> json) =>
+      _$SurveySubmissionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SurveySubmissionToJson(this);
+}
+
+@JsonSerializable()
+class SurveyQuestionSubmission {
+  String id;
+  List<SurveyAnswerSubmission> answers;
+
+  SurveyQuestionSubmission(this.id, this.answers);
+
+  factory SurveyQuestionSubmission.fromJson(Map<String, dynamic> json) =>
+      _$SurveyQuestionSubmissionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SurveyQuestionSubmissionToJson(this);
+}
+
+@JsonSerializable()
+class SurveyAnswerSubmission {
+  String id;
+  String answer;
+
+  SurveyAnswerSubmission(this.id, this.answer);
+
+  factory SurveyAnswerSubmission.fromJson(Map<String, dynamic> json) =>
+      _$SurveyAnswerSubmissionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SurveyAnswerSubmissionToJson(this);
+}

--- a/lib/api/graphql/mutation/create_response_mutation_input.g.dart
+++ b/lib/api/graphql/mutation/create_response_mutation_input.g.dart
@@ -1,0 +1,73 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'create_response_mutation_input.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CreateResponseMutationInput _$CreateResponseMutationInputFromJson(
+    Map<String, dynamic> json) {
+  return CreateResponseMutationInput(
+    json['response'] == null
+        ? null
+        : SurveySubmission.fromJson(json['response'] as Map<String, dynamic>),
+  );
+}
+
+Map<String, dynamic> _$CreateResponseMutationInputToJson(
+        CreateResponseMutationInput instance) =>
+    <String, dynamic>{
+      'response': instance.response,
+    };
+
+SurveySubmission _$SurveySubmissionFromJson(Map<String, dynamic> json) {
+  return SurveySubmission(
+    json['surveyId'] as String,
+    (json['questions'] as List)
+        ?.map((e) => e == null
+            ? null
+            : SurveyQuestionSubmission.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+  );
+}
+
+Map<String, dynamic> _$SurveySubmissionToJson(SurveySubmission instance) =>
+    <String, dynamic>{
+      'surveyId': instance.surveyId,
+      'questions': instance.questions,
+    };
+
+SurveyQuestionSubmission _$SurveyQuestionSubmissionFromJson(
+    Map<String, dynamic> json) {
+  return SurveyQuestionSubmission(
+    json['id'] as String,
+    (json['answers'] as List)
+        ?.map((e) => e == null
+            ? null
+            : SurveyAnswerSubmission.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+  );
+}
+
+Map<String, dynamic> _$SurveyQuestionSubmissionToJson(
+        SurveyQuestionSubmission instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'answers': instance.answers,
+    };
+
+SurveyAnswerSubmission _$SurveyAnswerSubmissionFromJson(
+    Map<String, dynamic> json) {
+  return SurveyAnswerSubmission(
+    json['id'] as String,
+    json['answer'] as String,
+  );
+}
+
+Map<String, dynamic> _$SurveyAnswerSubmissionToJson(
+        SurveyAnswerSubmission instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'answer': instance.answer,
+    };

--- a/lib/api/graphql/query/surveys_query.dart
+++ b/lib/api/graphql/query/surveys_query.dart
@@ -51,3 +51,11 @@ const String GET_SURVEY_BY_ID = r"""
     }
   }
 """;
+
+const String CREATE_RESPONSE = r"""
+  mutation($input: CreateResponseMutationInput!) {
+    createResponse(input: $input){
+      clientMutationId
+	  }
+  }
+""";

--- a/lib/pages/survey/survey_binding.dart
+++ b/lib/pages/survey/survey_binding.dart
@@ -8,6 +8,6 @@ class SurveyBinding implements Bindings {
   void dependencies() {
     final surveyRepository = Get.find<SurveyRepository>();
     Get.lazyPut(() => GetSurveyDetailUseCase(surveyRepository));
-    Get.lazyPut(() => CreateResponseUseCase(surveyRepository));
+    Get.lazyPut(() => CreateSurveyResponseUseCase(surveyRepository));
   }
 }

--- a/lib/pages/survey/survey_binding.dart
+++ b/lib/pages/survey/survey_binding.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 import 'package:survey/repositories/survey_repository.dart';
+import 'package:survey/use_cases/create_response_use_case.dart';
 import 'package:survey/use_cases/get_survey_detail_use_case.dart';
 
 class SurveyBinding implements Bindings {
@@ -7,5 +8,6 @@ class SurveyBinding implements Bindings {
   void dependencies() {
     final surveyRepository = Get.find<SurveyRepository>();
     Get.lazyPut(() => GetSurveyDetailUseCase(surveyRepository));
+    Get.lazyPut(() => CreateResponseUseCase(surveyRepository));
   }
 }

--- a/lib/repositories/survey_repository.dart
+++ b/lib/repositories/survey_repository.dart
@@ -37,18 +37,6 @@ class SurveyRepositoryImpl implements SurveyRepository {
 
   @override
   Future<Survey> getSurveyById(String id) {
-    /*final input = CreateResponseMutationInput(
-      SurveySubmission(
-        "d5de6a8f8f5f1cfe51bc",
-        [
-          SurveyQuestionSubmission("940d229e4cd87cd1e202", [
-            SurveyAnswerSubmission("037574cb93d16800eecd", "50"),
-            SurveyAnswerSubmission("037574cb93d16800eecd", "100"),
-          ])
-        ]
-      )
-    );
-    createResponse(input);*/
     final queryOptions = QueryOptions(
         fetchPolicy: FetchPolicy.cacheAndNetwork,
         document: gql(GET_SURVEY_BY_ID),

--- a/lib/repositories/survey_repository.dart
+++ b/lib/repositories/survey_repository.dart
@@ -1,4 +1,5 @@
 import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:survey/api/graphql/mutation/create_response_mutation_input.dart';
 import 'package:survey/api/graphql/query/surveys_query.dart';
 import 'package:survey/api/graphql/response/survey_response.dart';
 import 'package:survey/exception/network_exceptions.dart';
@@ -9,6 +10,8 @@ abstract class SurveyRepository {
   Future<List<Survey>> getSurveys(String cursor);
 
   Future<Survey> getSurveyById(String id);
+
+  Future<void> createResponse(CreateResponseMutationInput input);
 }
 
 class SurveyRepositoryImpl implements SurveyRepository {
@@ -34,6 +37,18 @@ class SurveyRepositoryImpl implements SurveyRepository {
 
   @override
   Future<Survey> getSurveyById(String id) {
+    /*final input = CreateResponseMutationInput(
+      SurveySubmission(
+        "d5de6a8f8f5f1cfe51bc",
+        [
+          SurveyQuestionSubmission("940d229e4cd87cd1e202", [
+            SurveyAnswerSubmission("037574cb93d16800eecd", "50"),
+            SurveyAnswerSubmission("037574cb93d16800eecd", "100"),
+          ])
+        ]
+      )
+    );
+    createResponse(input);*/
     final queryOptions = QueryOptions(
         fetchPolicy: FetchPolicy.cacheAndNetwork,
         document: gql(GET_SURVEY_BY_ID),
@@ -46,5 +61,15 @@ class SurveyRepositoryImpl implements SurveyRepository {
         throw NetworkExceptions.notFound("Something is wrong");
       }
     });
+  }
+
+  @override
+  Future<void> createResponse(CreateResponseMutationInput input) {
+    final mutationOption = MutationOptions(
+        fetchPolicy: FetchPolicy.networkOnly,
+        document: gql(CREATE_RESPONSE),
+        variables: {'input': input});
+
+    return _graphQlClient.mutate(mutationOption);
   }
 }

--- a/lib/use_cases/create_response_use_case.dart
+++ b/lib/use_cases/create_response_use_case.dart
@@ -30,7 +30,7 @@ class CreateSurveyResponseUseCase extends UseCase<bool, ResponseInput> {
       await _surveyRepository.createResponse(input);
       return Success(true);
     } catch (exception) {
-      return Success(false);
+      return Failed(exception);
     }
   }
 }

--- a/lib/use_cases/create_response_use_case.dart
+++ b/lib/use_cases/create_response_use_case.dart
@@ -1,0 +1,50 @@
+import 'package:survey/api/graphql/mutation/create_response_mutation_input.dart';
+import 'package:survey/repositories/survey_repository.dart';
+
+import 'base_use_case.dart';
+
+class CreateResponseUseCase extends UseCase<bool, ResponseInput> {
+  final SurveyRepository _surveyRepository;
+
+  CreateResponseUseCase(this._surveyRepository);
+
+  @override
+  Future<Result<bool>> call(ResponseInput params) async {
+    try {
+      final input = CreateResponseMutationInput(
+        SurveySubmission(
+          params.surveyId,
+          params.questionsAndAnswers.entries
+              .map(
+                (entry) => SurveyQuestionSubmission(
+                  entry.key, // each question (id)
+                  entry.value // all answers
+                      .map((answer) =>
+                          SurveyAnswerSubmission(answer.id, answer.answer))
+                      .toList(),
+                ),
+              )
+              .toList(),
+        ),
+      );
+      await _surveyRepository.createResponse(input);
+      return Success(true);
+    } catch (exception) {
+      return Success(false);
+    }
+  }
+}
+
+class ResponseInput {
+  final String surveyId;
+  Map<String, List<AnswerDetail>> questionsAndAnswers = {};
+
+  ResponseInput(this.surveyId);
+}
+
+class AnswerDetail {
+  String id;
+  String answer;
+
+  AnswerDetail(this.id, this.answer);
+}

--- a/lib/use_cases/create_response_use_case.dart
+++ b/lib/use_cases/create_response_use_case.dart
@@ -3,10 +3,10 @@ import 'package:survey/repositories/survey_repository.dart';
 
 import 'base_use_case.dart';
 
-class CreateResponseUseCase extends UseCase<bool, ResponseInput> {
+class CreateSurveyResponseUseCase extends UseCase<bool, ResponseInput> {
   final SurveyRepository _surveyRepository;
 
-  CreateResponseUseCase(this._surveyRepository);
+  CreateSurveyResponseUseCase(this._surveyRepository);
 
   @override
   Future<Result<bool>> call(ResponseInput params) async {


### PR DESCRIPTION
Closes #91 

## What happened 👀

Add backend integration to submit answer
 
## Insight 📝

- It's like a POST request, in GraphQL it's a Mutation.
- Here is an example:
```
mutation createResponse($input: CreateResponseMutationInput!) {
  createResponse(input: $input){
    clientMutationId
	}
}

// Then adding the variable:
{
  "input": {
    "response": {
      "surveyId": "d5de6a8f8f5f1cfe51bc",
      "questions": [
        {
          "id": "940d229e4cd87cd1e202",
          "answers": [
            {
            "id": "037574cb93d16800eecd",
            "answer": "50"
            },
            {
            "id": "037574cb93d16800eecd",
            "answer": "50"
          }
          ]
        }
      ]
    }
  }
}
```
 
## Proof Of Work 📹
Successfully call:
<img src="https://user-images.githubusercontent.com/13435717/125946311-4e9c8311-ebbe-42b1-a5ec-e45f56a01520.png" width=400 />

