### PR TITLE
Improvement: precache photos

### DIFF
--- a/lib/pages/survey/survey_controller.dart
+++ b/lib/pages/survey/survey_controller.dart
@@ -19,6 +19,14 @@ class SurveyController extends GetxController {
   SurveyQuestion get currentQuestion =>
       optionalSurvey.value.questions[currentQuestionIndex];
 
+  String get nextQuestionImage {
+    if (currentQuestionIndex != optionalSurvey.value.questions.length - 1) {
+      return optionalSurvey
+          .value.questions[currentQuestionIndex + 1].hdCoverImageUrl;
+    }
+    return null;
+  }
+
   String get indexTitleText => _getIndexText();
 
   @override

--- a/lib/pages/survey/survey_question_page.dart
+++ b/lib/pages/survey/survey_question_page.dart
@@ -17,6 +17,11 @@ class SurveyQuestionPage extends StatelessWidget {
           init: SurveyController(),
           builder: (_) {
             return GetX<SurveyController>(builder: (controller) {
+              if (controller.nextQuestionImage != null) {
+                precacheImage(
+                    CachedNetworkImageProvider(controller.nextQuestionImage),
+                    context);
+              }
               return Stack(
                 children: [
                   _buildBackground(controller.currentQuestion),


### PR DESCRIPTION
## What happened 👀

A small improvement to preload/precache the photo of the subsequent survey question so the transition can happen smoothly.
 
## Insight 📝

Learn and use the `precacheImage` function; expose the next photo image as a nullable field to the View to preload and cache it.
 
## Proof Of Work 📹

Navigating through the questions in a very fast manner, you can see that the background image is loaded like instantly, even though we are loading high-quality images:

https://user-images.githubusercontent.com/13435717/126192676-f17e2e94-ebe2-4ab8-a821-bc1e776e7630.mp4


