### PR TITLE
[#23] Integrate submit rate answers [Part 1]

### DIFF
--- a/lib/pages/survey/survey_answer_selection.dart
+++ b/lib/pages/survey/survey_answer_selection.dart
@@ -10,39 +10,40 @@ import 'package:survey/pages/ui/text_field_rating.dart';
 
 class SurveyAnswerSelection extends StatelessWidget {
   final String type;
-  final List<String> optionsText;
+  final Map<String, String> optionIdAndText;
   final int counter;
 
-  SurveyAnswerSelection({this.type, this.optionsText, this.counter = -1});
+  SurveyAnswerSelection({this.type, this.optionIdAndText, this.counter = -1});
 
   @override
   Widget build(BuildContext context) {
-    return _processAnswerUi(type, optionsText, counter);
+    return _processAnswerUi(type, optionIdAndText, counter);
   }
 }
 
-Widget _processAnswerUi(String type, List<String> optionsText, int counter) {
+Widget _processAnswerUi(
+    String type, Map<String, String> optionIdAndText, int counter) {
   switch (type) {
     case RATING_TYPE_STAR:
     case RATING_TYPE_HEART:
     case RATING_TYPE_MONEY:
-      return SlideRatingBar.from(type, counter);
+      return SlideRatingBar.from(type, optionIdAndText.keys.toList());
     case RATING_TYPE_CHOICE:
-      return MultipleChoiceRating(choices: optionsText);
+      return MultipleChoiceRating(idAndChoice: optionIdAndText);
     case RATING_TYPE_DROPDOWN:
-      return PickerSelector(optionsText: optionsText);
+      return PickerSelector(idAndChoice: optionIdAndText);
     case RATING_TYPE_SLIDER:
     case RATING_TYPE_NPS:
       return NpsRatingBar(
-          counter: counter,
-          minTitle: optionsText.first,
-          maxTitle: optionsText.last);
+          ids: optionIdAndText.keys.toList(),
+          minTitle: optionIdAndText.values.toList().first,
+          maxTitle: optionIdAndText.values.toList().last);
     case RATING_TYPE_SMILEY:
-      return SmileyRatingBar(counter);
+      return SmileyRatingBar(optionIdAndText.keys.toList());
     case RATING_TYPE_TEXT_AREA:
-      return TextAreaRating(optionsText.first);
+      return TextAreaRating(optionIdAndText.values.toList().first);
     case RATING_TYPE_TEXT_FIELD:
-      return TextFieldRating(hints: optionsText);
+      return TextFieldRating(hints: optionIdAndText.values.toList());
     default:
       return SizedBox.shrink();
   }

--- a/lib/pages/survey/survey_answer_selection.dart
+++ b/lib/pages/survey/survey_answer_selection.dart
@@ -12,34 +12,43 @@ class SurveyAnswerSelection extends StatelessWidget {
   final String type;
   final Map<String, String> optionIdAndText;
   final int counter;
+  final Function(Map<String, String>) onRatingListener;
 
-  SurveyAnswerSelection({this.type, this.optionIdAndText, this.counter = -1});
+  SurveyAnswerSelection(
+      {this.type,
+      this.optionIdAndText,
+      this.counter = -1,
+      @required this.onRatingListener});
 
   @override
   Widget build(BuildContext context) {
-    return _processAnswerUi(type, optionIdAndText, counter);
+    return _processAnswerUi(type, optionIdAndText, counter, onRatingListener);
   }
 }
 
-Widget _processAnswerUi(
-    String type, Map<String, String> optionIdAndText, int counter) {
+Widget _processAnswerUi(String type, Map<String, String> optionIdAndText,
+    int counter, Function(Map<String, String>) onRatingListener) {
   switch (type) {
     case RATING_TYPE_STAR:
     case RATING_TYPE_HEART:
     case RATING_TYPE_MONEY:
-      return SlideRatingBar.from(type, optionIdAndText.keys.toList());
+      return SlideRatingBar.from(
+          type, optionIdAndText.keys.toList(), onRatingListener);
     case RATING_TYPE_CHOICE:
-      return MultipleChoiceRating(idAndChoice: optionIdAndText);
+      return MultipleChoiceRating(
+          idAndChoice: optionIdAndText, onRatingListener: onRatingListener);
     case RATING_TYPE_DROPDOWN:
-      return PickerSelector(idAndChoice: optionIdAndText);
+      return PickerSelector(
+          idAndChoice: optionIdAndText, onRatingListener: onRatingListener);
     case RATING_TYPE_SLIDER:
     case RATING_TYPE_NPS:
       return NpsRatingBar(
           ids: optionIdAndText.keys.toList(),
           minTitle: optionIdAndText.values.toList().first,
-          maxTitle: optionIdAndText.values.toList().last);
+          maxTitle: optionIdAndText.values.toList().last,
+          onRatingListener: onRatingListener);
     case RATING_TYPE_SMILEY:
-      return SmileyRatingBar(optionIdAndText.keys.toList());
+      return SmileyRatingBar(optionIdAndText.keys.toList(), onRatingListener);
     case RATING_TYPE_TEXT_AREA:
       return TextAreaRating(optionIdAndText.values.toList().first);
     case RATING_TYPE_TEXT_FIELD:

--- a/lib/pages/survey/survey_controller.dart
+++ b/lib/pages/survey/survey_controller.dart
@@ -67,6 +67,8 @@ class SurveyController extends GetxController {
           List.from(_currentAnswer);
       _currentAnswer.clear();
     }
+
+    // TODO: remove this debug log later
     print("ResponseInput: $_responseInput");
 
     _currentQuestion.value = currentQuestionIndex + 1;
@@ -76,6 +78,8 @@ class SurveyController extends GetxController {
     _currentAnswer = idAndAnswer.entries
         .map((entry) => AnswerDetail(entry.key, entry.value))
         .toList();
+
+    // TODO: remove this debug log later
     print("Rated on: Question: ${currentQuestion.id} Answers: $_currentAnswer");
   }
 }

--- a/lib/pages/survey/survey_controller.dart
+++ b/lib/pages/survey/survey_controller.dart
@@ -3,6 +3,7 @@ import 'package:optional/optional.dart';
 import 'package:survey/models/survey.dart';
 import 'package:survey/navigator/const.dart';
 import 'package:survey/use_cases/base_use_case.dart';
+import 'package:survey/use_cases/create_response_use_case.dart';
 import 'package:survey/use_cases/get_survey_detail_use_case.dart';
 
 class SurveyController extends GetxController {
@@ -29,6 +30,9 @@ class SurveyController extends GetxController {
 
   String get indexTitleText => _getIndexText();
 
+  ResponseInput _responseInput;
+  List<AnswerDetail> _currentAnswer = List.empty(growable: true);
+
   @override
   void onInit() {
     super.onInit();
@@ -41,6 +45,7 @@ class SurveyController extends GetxController {
     getSurveyUseCase.call(surveyId).then((result) {
       if (result is Success<Survey>) {
         _survey.value = Optional.of(result.value);
+        _responseInput = ResponseInput(result.value.id);
       } else {
         print("Error when fetching survey, handle Error later.");
       }
@@ -57,6 +62,20 @@ class SurveyController extends GetxController {
       // TODO: do submission
       return;
     }
+    if (!currentQuestion.doesNotRequireAnswer) {
+      _responseInput.questionsAndAnswers[currentQuestion.id] =
+          List.from(_currentAnswer);
+      _currentAnswer.clear();
+    }
+    print("ResponseInput: $_responseInput");
+
     _currentQuestion.value = currentQuestionIndex + 1;
+  }
+
+  void onAnswerSelected(Map<String, String> idAndAnswer) {
+    _currentAnswer = idAndAnswer.entries
+        .map((entry) => AnswerDetail(entry.key, entry.value))
+        .toList();
+    print("Rated on: Question: ${currentQuestion.id} Answers: $_currentAnswer");
   }
 }

--- a/lib/pages/survey/survey_question_page.dart
+++ b/lib/pages/survey/survey_question_page.dart
@@ -123,7 +123,6 @@ class SurveyQuestionPage extends StatelessWidget {
     return SafeArea(
       child: PageView.builder(
         physics: NeverScrollableScrollPhysics(),
-        allowImplicitScrolling: false,
         itemBuilder: (context, index) => Center(
           child: SurveyAnswerSelection(
             type: questions[index].displayType,

--- a/lib/pages/survey/survey_question_page.dart
+++ b/lib/pages/survey/survey_question_page.dart
@@ -123,11 +123,12 @@ class SurveyQuestionPage extends StatelessWidget {
     return SafeArea(
       child: PageView.builder(
         physics: NeverScrollableScrollPhysics(),
+        allowImplicitScrolling: false,
         itemBuilder: (context, index) => Center(
           child: SurveyAnswerSelection(
             type: questions[index].displayType,
-            optionsText:
-                questions[index].answers.map((e) => e.text ?? "").toList(),
+            optionIdAndText: Map.fromIterable(questions[index].answers,
+                key: (e) => e.id, value: (e) => e.text),
             counter: questions[index].answers.length ?? 0,
           ),
         ),
@@ -150,7 +151,6 @@ class SurveyQuestionPage extends StatelessWidget {
         onPressed: () {
           _answersController.nextPage(
               duration: Duration(milliseconds: 500), curve: Curves.ease);
-
           final surveyController = Get.find<SurveyController>();
           surveyController.onNextQuestion();
         },

--- a/lib/pages/survey/survey_question_page.dart
+++ b/lib/pages/survey/survey_question_page.dart
@@ -129,6 +129,10 @@ class SurveyQuestionPage extends StatelessWidget {
             optionIdAndText: Map.fromIterable(questions[index].answers,
                 key: (e) => e.id, value: (e) => e.text),
             counter: questions[index].answers.length ?? 0,
+            onRatingListener: (idAndText) {
+              final surveyController = Get.find<SurveyController>();
+              surveyController.onAnswerSelected(idAndText);
+            },
           ),
         ),
         itemCount: questions.length,

--- a/lib/pages/ui/multiple_choice_rating.dart
+++ b/lib/pages/ui/multiple_choice_rating.dart
@@ -25,10 +25,11 @@ class _MultipleChoiceRatingState extends State<MultipleChoiceRating> {
       _isSelected(index)
           ? _selectedIndexes.remove(index)
           : _selectedIndexes.add(index);
-      final answers = Map.fromIterable(_selectedIndexes,
-          key: (e) => widget.idAndChoice.keys.toList()[e], value: (_) => "");
-      widget.onRatingListener.call(answers);
     });
+
+    final answers = Map.fromIterable(_selectedIndexes,
+        key: (e) => widget.idAndChoice.keys.toList()[e], value: (_) => "");
+    widget.onRatingListener.call(answers);
   }
 
   bool _shouldDrawDivider(int index) {

--- a/lib/pages/ui/multiple_choice_rating.dart
+++ b/lib/pages/ui/multiple_choice_rating.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:survey/pages/survey/survey_controller.dart';
 
 class MultipleChoiceRating extends StatefulWidget {
-  final List<String> choices;
+  final Map<String, String> idAndChoice;
 
-  const MultipleChoiceRating({Key key, this.choices}) : super(key: key);
+  const MultipleChoiceRating({Key key, this.idAndChoice}) : super(key: key);
 
   @override
   State<StatefulWidget> createState() => _MultipleChoiceRatingState();
@@ -12,6 +14,7 @@ class MultipleChoiceRating extends StatefulWidget {
 
 class _MultipleChoiceRatingState extends State<MultipleChoiceRating> {
   final _selectedIndexes = <int>[];
+  final _surveyController = Get.find<SurveyController>();
 
   bool _isSelected(int index) {
     return _selectedIndexes.contains(index);
@@ -22,11 +25,14 @@ class _MultipleChoiceRatingState extends State<MultipleChoiceRating> {
       _isSelected(index)
           ? _selectedIndexes.remove(index)
           : _selectedIndexes.add(index);
+      final answers = Map.fromIterable(_selectedIndexes,
+          key: (e) => widget.idAndChoice.keys.toList()[e], value: (_) => "");
+      _surveyController.onAnswerSelected(answers);
     });
   }
 
   bool _shouldDrawDivider(int index) {
-    return index == widget.choices.length - 1 ? false : true;
+    return index == widget.idAndChoice.values.length - 1 ? false : true;
   }
 
   @override
@@ -36,7 +42,7 @@ class _MultipleChoiceRatingState extends State<MultipleChoiceRating> {
       alignment: Alignment.center,
       child: ListView.builder(
         scrollDirection: Axis.vertical,
-        itemCount: widget.choices.length,
+        itemCount: widget.idAndChoice.values.length,
         itemBuilder: (context, index) {
           return GestureDetector(
             onTap: () {
@@ -52,7 +58,7 @@ class _MultipleChoiceRatingState extends State<MultipleChoiceRating> {
                     children: [
                       Expanded(
                         child: Text(
-                          widget.choices[index],
+                          widget.idAndChoice.values.toList()[index],
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,
                           style: Theme.of(context).textTheme.bodyText1.copyWith(

--- a/lib/pages/ui/multiple_choice_rating.dart
+++ b/lib/pages/ui/multiple_choice_rating.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
-import 'package:survey/pages/survey/survey_controller.dart';
 
 class MultipleChoiceRating extends StatefulWidget {
   final Map<String, String> idAndChoice;
+  final void Function(Map<String, String>) onRatingListener;
 
-  const MultipleChoiceRating({Key key, this.idAndChoice}) : super(key: key);
+  const MultipleChoiceRating(
+      {Key key, this.idAndChoice, @required this.onRatingListener})
+      : super(key: key);
 
   @override
   State<StatefulWidget> createState() => _MultipleChoiceRatingState();
@@ -14,7 +15,6 @@ class MultipleChoiceRating extends StatefulWidget {
 
 class _MultipleChoiceRatingState extends State<MultipleChoiceRating> {
   final _selectedIndexes = <int>[];
-  final _surveyController = Get.find<SurveyController>();
 
   bool _isSelected(int index) {
     return _selectedIndexes.contains(index);
@@ -27,7 +27,7 @@ class _MultipleChoiceRatingState extends State<MultipleChoiceRating> {
           : _selectedIndexes.add(index);
       final answers = Map.fromIterable(_selectedIndexes,
           key: (e) => widget.idAndChoice.keys.toList()[e], value: (_) => "");
-      _surveyController.onAnswerSelected(answers);
+      widget.onRatingListener.call(answers);
     });
   }
 

--- a/lib/pages/ui/nps_rating_bar.dart
+++ b/lib/pages/ui/nps_rating_bar.dart
@@ -26,16 +26,16 @@ class _NpsRatingBarState extends State<NpsRatingBar> {
   int _selectedRate = DEFAULT_SELECTED_RATE;
 
   void _onRateSelected(int rate) {
+    widget.onRatingListener.call({widget.ids[rate]: ""});
     setState(() {
       _selectedRate = rate;
-      widget.onRatingListener.call({widget.ids[rate]: ""});
     });
   }
 
   @override
-  void didChangeDependencies() {
+  void initState() {
     widget.onRatingListener.call({widget.ids[DEFAULT_SELECTED_RATE]: ""});
-    super.didChangeDependencies();
+    super.initState();
   }
 
   @override

--- a/lib/pages/ui/nps_rating_bar.dart
+++ b/lib/pages/ui/nps_rating_bar.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:survey/pages/survey/survey_controller.dart';
 
 const String RATING_TYPE_NPS = "nps";
+const int DEFAULT_SELECTED_RATE = 4;
 
 class NpsRatingBar extends StatefulWidget {
-  final int counter;
+  final List<String> ids;
   final String minTitle;
   final String maxTitle;
 
-  NpsRatingBar({Key key, this.counter, this.minTitle, this.maxTitle})
+  NpsRatingBar({Key key, this.ids, this.minTitle, this.maxTitle})
       : super(key: key);
 
   @override
@@ -16,12 +19,20 @@ class NpsRatingBar extends StatefulWidget {
 }
 
 class _NpsRatingBarState extends State<NpsRatingBar> {
-  int _selectedRate = 4;
+  int _selectedRate = DEFAULT_SELECTED_RATE;
+  final _surveyController = Get.find<SurveyController>();
 
   void _onRateSelected(int rate) {
     setState(() {
       _selectedRate = rate;
+      _surveyController.onAnswerSelected({widget.ids[rate]: ""});
     });
+  }
+
+  @override
+  void didChangeDependencies() {
+    _surveyController.onAnswerSelected({widget.ids[DEFAULT_SELECTED_RATE]: ""});
+    super.didChangeDependencies();
   }
 
   @override
@@ -39,7 +50,7 @@ class _NpsRatingBarState extends State<NpsRatingBar> {
             child: ListView.builder(
               shrinkWrap: true,
               scrollDirection: Axis.horizontal,
-              itemCount: widget.counter,
+              itemCount: widget.ids.length,
               itemBuilder: (context, index) {
                 return GestureDetector(
                   onTap: () {
@@ -55,10 +66,10 @@ class _NpsRatingBarState extends State<NpsRatingBar> {
                             : Colors.white30,
                         width: 1,
                       ),
-                      borderRadius: _roundedBorder(index, widget.counter),
+                      borderRadius: _roundedBorder(index, widget.ids.length),
                     ),
                     child: Text(
-                      (index + 1).toString(),
+                      index.toString(),
                       style: style.copyWith(
                         color: (_selectedRate != null && _selectedRate >= index)
                             ? Colors.white
@@ -80,7 +91,7 @@ class _NpsRatingBarState extends State<NpsRatingBar> {
                   widget.minTitle,
                   style: style.copyWith(
                     color: (_selectedRate != null &&
-                            _selectedRate >= widget.counter / 2)
+                            _selectedRate >= widget.ids.length / 2)
                         ? Colors.white30
                         : Colors.white,
                   ),
@@ -88,7 +99,7 @@ class _NpsRatingBarState extends State<NpsRatingBar> {
                 Text(widget.maxTitle,
                     style: style.copyWith(
                       color: (_selectedRate != null &&
-                              _selectedRate >= widget.counter / 2)
+                              _selectedRate >= widget.ids.length / 2)
                           ? Colors.white
                           : Colors.white30,
                     )),

--- a/lib/pages/ui/nps_rating_bar.dart
+++ b/lib/pages/ui/nps_rating_bar.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
-import 'package:survey/pages/survey/survey_controller.dart';
 
 const String RATING_TYPE_NPS = "nps";
 const int DEFAULT_SELECTED_RATE = 4;
@@ -10,8 +8,14 @@ class NpsRatingBar extends StatefulWidget {
   final List<String> ids;
   final String minTitle;
   final String maxTitle;
+  final Function(Map<String, String>) onRatingListener;
 
-  NpsRatingBar({Key key, this.ids, this.minTitle, this.maxTitle})
+  NpsRatingBar(
+      {Key key,
+      this.ids,
+      this.minTitle,
+      this.maxTitle,
+      @required this.onRatingListener})
       : super(key: key);
 
   @override
@@ -20,18 +24,17 @@ class NpsRatingBar extends StatefulWidget {
 
 class _NpsRatingBarState extends State<NpsRatingBar> {
   int _selectedRate = DEFAULT_SELECTED_RATE;
-  final _surveyController = Get.find<SurveyController>();
 
   void _onRateSelected(int rate) {
     setState(() {
       _selectedRate = rate;
-      _surveyController.onAnswerSelected({widget.ids[rate]: ""});
+      widget.onRatingListener.call({widget.ids[rate]: ""});
     });
   }
 
   @override
   void didChangeDependencies() {
-    _surveyController.onAnswerSelected({widget.ids[DEFAULT_SELECTED_RATE]: ""});
+    widget.onRatingListener.call({widget.ids[DEFAULT_SELECTED_RATE]: ""});
     super.didChangeDependencies();
   }
 

--- a/lib/pages/ui/picker_selector.dart
+++ b/lib/pages/ui/picker_selector.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:get/get.dart';
+import 'package:survey/pages/survey/survey_controller.dart';
 
 const double ITEM_SIZE = 50.0;
 
@@ -8,22 +10,24 @@ const String RATING_TYPE_CHOICE = "choice";
 const String RATING_TYPE_DROPDOWN = "dropdown";
 
 class PickerSelector extends StatelessWidget {
-  final List<String> optionsText;
+  final Map<String, String> idAndChoice;
 
-  PickerSelector({@required this.optionsText});
+  PickerSelector({@required this.idAndChoice});
 
   @override
   Widget build(BuildContext context) {
+    final surveyController = Get.find<SurveyController>();
+    surveyController.onAnswerSelected({idAndChoice.keys.first: ""});
     return Center(
       child: SizedBox(
         height: 150,
         child: CupertinoPicker(
           itemExtent: ITEM_SIZE,
           selectionOverlay: CustomPaint(painter: TwoHorizontalLinesPainter()),
-          children: _getOptionWidgets(context, optionsText),
+          children: _getOptionWidgets(context, idAndChoice.values.toList()),
           onSelectedItemChanged: (index) {
-            // TODO: update this behavior to ViewModel
-            print("Selected: $index");
+            surveyController
+                .onAnswerSelected({idAndChoice.keys.toList()[index]: ""});
           },
         ),
       ),

--- a/lib/pages/ui/picker_selector.dart
+++ b/lib/pages/ui/picker_selector.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:get/get.dart';
-import 'package:survey/pages/survey/survey_controller.dart';
 
 const double ITEM_SIZE = 50.0;
 
@@ -11,13 +9,13 @@ const String RATING_TYPE_DROPDOWN = "dropdown";
 
 class PickerSelector extends StatelessWidget {
   final Map<String, String> idAndChoice;
+  final void Function(Map<String, String>) onRatingListener;
 
-  PickerSelector({@required this.idAndChoice});
+  PickerSelector({@required this.idAndChoice, @required this.onRatingListener});
 
   @override
   Widget build(BuildContext context) {
-    final surveyController = Get.find<SurveyController>();
-    surveyController.onAnswerSelected({idAndChoice.keys.first: ""});
+    onRatingListener.call({idAndChoice.keys.first: ""});
     return Center(
       child: SizedBox(
         height: 150,
@@ -26,8 +24,7 @@ class PickerSelector extends StatelessWidget {
           selectionOverlay: CustomPaint(painter: TwoHorizontalLinesPainter()),
           children: _getOptionWidgets(context, idAndChoice.values.toList()),
           onSelectedItemChanged: (index) {
-            surveyController
-                .onAnswerSelected({idAndChoice.keys.toList()[index]: ""});
+            onRatingListener.call({idAndChoice.keys.toList()[index]: ""});
           },
         ),
       ),

--- a/lib/pages/ui/slide_rating_bar.dart
+++ b/lib/pages/ui/slide_rating_bar.dart
@@ -1,46 +1,68 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
+import 'package:get/get.dart';
+import 'package:survey/pages/survey/survey_controller.dart';
 
 const int DEFAULT_RATE_COUNT = 5;
+const int DEFAULT_SELECTED_RATE_INDEX = 2;
 const String RATING_TYPE_HEART = "heart";
 const String RATING_TYPE_SLIDER = "slider";
 const String RATING_TYPE_MONEY = "money";
 const String RATING_TYPE_STAR = "star";
 
-class SlideRatingBar extends StatelessWidget {
+class SlideRatingBar extends StatefulWidget {
   final RatingType type;
+  final List<String> values;
 
-  SlideRatingBar({this.type});
+  SlideRatingBar({this.type, this.values});
 
-  factory SlideRatingBar.from(String type, int counter) {
-    final actualCounter = counter == -1 ? DEFAULT_RATE_COUNT : counter;
+  factory SlideRatingBar.from(String type, List<String> ids) {
+    final actualCounter = ids.length == -1 ? DEFAULT_RATE_COUNT : ids.length;
     switch (type) {
       case RATING_TYPE_HEART:
-        return SlideRatingBar(type: HeartRatingType(counter: actualCounter));
+        return SlideRatingBar(
+            type: HeartRatingType(counter: actualCounter), values: ids);
       case RATING_TYPE_SLIDER:
-        return SlideRatingBar(type: SliderRatingType(counter: actualCounter));
+        return SlideRatingBar(
+            type: SliderRatingType(counter: actualCounter), values: ids);
       case RATING_TYPE_MONEY:
-        return SlideRatingBar(type: MoneyRatingType(counter: actualCounter));
+        return SlideRatingBar(
+            type: MoneyRatingType(counter: actualCounter), values: ids);
       case RATING_TYPE_STAR:
       default:
-        return SlideRatingBar(type: StarRatingType(counter: actualCounter));
+        return SlideRatingBar(
+            type: StarRatingType(counter: actualCounter), values: ids);
     }
+  }
+
+  @override
+  State<SlideRatingBar> createState() => _SlideRatingBarState();
+}
+
+class _SlideRatingBarState extends State<SlideRatingBar> {
+  final _surveyController = Get.find<SurveyController>();
+
+  @override
+  void didChangeDependencies() {
+    final defaultSelection = {widget.values[DEFAULT_SELECTED_RATE_INDEX]: ""};
+    _surveyController.onAnswerSelected(defaultSelection);
+    super.didChangeDependencies();
   }
 
   @override
   Widget build(BuildContext context) {
     return RatingBar.builder(
-      initialRating: 3,
+      initialRating: DEFAULT_SELECTED_RATE_INDEX.toDouble() + 1,
       minRating: 1,
-      unratedColor: type.unratedColor,
+      unratedColor: widget.type.unratedColor,
       direction: Axis.horizontal,
-      itemCount: type.counter,
+      itemCount: widget.type.counter,
       itemPadding: EdgeInsets.symmetric(horizontal: 5.0),
-      itemBuilder: (context, _) => type.icon,
+      itemBuilder: (context, _) => widget.type.icon,
       onRatingUpdate: (rating) {
-        // TODO: update choice to ViewModel
-        print(rating);
+        _surveyController
+            .onAnswerSelected({widget.values[rating.toInt() - 1]: ""});
       },
     );
   }

--- a/lib/pages/ui/slide_rating_bar.dart
+++ b/lib/pages/ui/slide_rating_bar.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
-import 'package:get/get.dart';
-import 'package:survey/pages/survey/survey_controller.dart';
 
 const int DEFAULT_RATE_COUNT = 5;
 const int DEFAULT_SELECTED_RATE_INDEX = 2;
@@ -13,26 +11,43 @@ const String RATING_TYPE_STAR = "star";
 
 class SlideRatingBar extends StatefulWidget {
   final RatingType type;
-  final List<String> values;
+  final List<String> ids;
+  final void Function(Map<String, String>) onRatingListener;
 
-  SlideRatingBar({this.type, this.values});
+  SlideRatingBar(
+      {@required this.type,
+      @required this.ids,
+      @required this.onRatingListener});
 
-  factory SlideRatingBar.from(String type, List<String> ids) {
+  factory SlideRatingBar.from(String type, List<String> ids,
+      Function(Map<String, String>) onRatingListener) {
     final actualCounter = ids.length == -1 ? DEFAULT_RATE_COUNT : ids.length;
     switch (type) {
       case RATING_TYPE_HEART:
         return SlideRatingBar(
-            type: HeartRatingType(counter: actualCounter), values: ids);
+          type: HeartRatingType(counter: actualCounter),
+          ids: ids,
+          onRatingListener: onRatingListener,
+        );
       case RATING_TYPE_SLIDER:
         return SlideRatingBar(
-            type: SliderRatingType(counter: actualCounter), values: ids);
+          type: SliderRatingType(counter: actualCounter),
+          ids: ids,
+          onRatingListener: onRatingListener,
+        );
       case RATING_TYPE_MONEY:
         return SlideRatingBar(
-            type: MoneyRatingType(counter: actualCounter), values: ids);
+          type: MoneyRatingType(counter: actualCounter),
+          ids: ids,
+          onRatingListener: onRatingListener,
+        );
       case RATING_TYPE_STAR:
       default:
         return SlideRatingBar(
-            type: StarRatingType(counter: actualCounter), values: ids);
+          type: StarRatingType(counter: actualCounter),
+          ids: ids,
+          onRatingListener: onRatingListener,
+        );
     }
   }
 
@@ -41,12 +56,9 @@ class SlideRatingBar extends StatefulWidget {
 }
 
 class _SlideRatingBarState extends State<SlideRatingBar> {
-  final _surveyController = Get.find<SurveyController>();
-
   @override
   void didChangeDependencies() {
-    final defaultSelection = {widget.values[DEFAULT_SELECTED_RATE_INDEX]: ""};
-    _surveyController.onAnswerSelected(defaultSelection);
+    widget.onRatingListener.call({widget.ids[DEFAULT_SELECTED_RATE_INDEX]: ""});
     super.didChangeDependencies();
   }
 
@@ -61,8 +73,7 @@ class _SlideRatingBarState extends State<SlideRatingBar> {
       itemPadding: EdgeInsets.symmetric(horizontal: 5.0),
       itemBuilder: (context, _) => widget.type.icon,
       onRatingUpdate: (rating) {
-        _surveyController
-            .onAnswerSelected({widget.values[rating.toInt() - 1]: ""});
+        widget.onRatingListener.call({widget.ids[rating.toInt() - 1]: ""});
       },
     );
   }

--- a/lib/pages/ui/slide_rating_bar.dart
+++ b/lib/pages/ui/slide_rating_bar.dart
@@ -57,9 +57,9 @@ class SlideRatingBar extends StatefulWidget {
 
 class _SlideRatingBarState extends State<SlideRatingBar> {
   @override
-  void didChangeDependencies() {
+  void initState() {
     widget.onRatingListener.call({widget.ids[DEFAULT_SELECTED_RATE_INDEX]: ""});
-    super.didChangeDependencies();
+    super.initState();
   }
 
   @override

--- a/lib/pages/ui/smiley_rating_bar.dart
+++ b/lib/pages/ui/smiley_rating_bar.dart
@@ -25,16 +25,16 @@ class _SmileyRatingBarState extends State<SmileyRatingBar> {
   int _selectedRate = DEFAULT_SELECTED_RATE;
 
   void _onRateSelected(int rate) {
+    widget.onRatingListener.call({widget.ids[rate]: ""});
     setState(() {
       _selectedRate = rate;
-      widget.onRatingListener.call({widget.ids[rate]: ""});
     });
   }
 
   @override
-  void didChangeDependencies() {
+  void initState() {
     widget.onRatingListener.call({widget.ids[DEFAULT_SELECTED_RATE]: ""});
-    super.didChangeDependencies();
+    super.initState();
   }
 
   @override

--- a/lib/pages/ui/smiley_rating_bar.dart
+++ b/lib/pages/ui/smiley_rating_bar.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
-import 'package:survey/pages/survey/survey_controller.dart';
 
 const String RATING_TYPE_SMILEY = "smiley";
 const int DEFAULT_SELECTED_RATE = 2;
@@ -15,8 +13,9 @@ const _smileys = {
 
 class SmileyRatingBar extends StatefulWidget {
   final List<String> ids;
+  final Function(Map<String, String>) onRatingListener;
 
-  SmileyRatingBar(this.ids);
+  SmileyRatingBar(this.ids, this.onRatingListener);
 
   @override
   _SmileyRatingBarState createState() => _SmileyRatingBarState();
@@ -24,18 +23,17 @@ class SmileyRatingBar extends StatefulWidget {
 
 class _SmileyRatingBarState extends State<SmileyRatingBar> {
   int _selectedRate = DEFAULT_SELECTED_RATE;
-  final _surveyController = Get.find<SurveyController>();
 
   void _onRateSelected(int rate) {
     setState(() {
       _selectedRate = rate;
-      _surveyController.onAnswerSelected({widget.ids[rate]: ""});
+      widget.onRatingListener.call({widget.ids[rate]: ""});
     });
   }
 
   @override
   void didChangeDependencies() {
-    _surveyController.onAnswerSelected({widget.ids[DEFAULT_SELECTED_RATE]: ""});
+    widget.onRatingListener.call({widget.ids[DEFAULT_SELECTED_RATE]: ""});
     super.didChangeDependencies();
   }
 

--- a/lib/pages/ui/smiley_rating_bar.dart
+++ b/lib/pages/ui/smiley_rating_bar.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:survey/pages/survey/survey_controller.dart';
 
 const String RATING_TYPE_SMILEY = "smiley";
+const int DEFAULT_SELECTED_RATE = 2;
 const _smileys = {
   "worst": "😡",
   "worse": "😕",
@@ -11,21 +14,29 @@ const _smileys = {
 };
 
 class SmileyRatingBar extends StatefulWidget {
-  final int counter;
+  final List<String> ids;
 
-  SmileyRatingBar(this.counter);
+  SmileyRatingBar(this.ids);
 
   @override
   _SmileyRatingBarState createState() => _SmileyRatingBarState();
 }
 
 class _SmileyRatingBarState extends State<SmileyRatingBar> {
-  int _selectedRate = 2;
+  int _selectedRate = DEFAULT_SELECTED_RATE;
+  final _surveyController = Get.find<SurveyController>();
 
   void _onRateSelected(int rate) {
     setState(() {
       _selectedRate = rate;
+      _surveyController.onAnswerSelected({widget.ids[rate]: ""});
     });
+  }
+
+  @override
+  void didChangeDependencies() {
+    _surveyController.onAnswerSelected({widget.ids[DEFAULT_SELECTED_RATE]: ""});
+    super.didChangeDependencies();
   }
 
   @override
@@ -38,7 +49,7 @@ class _SmileyRatingBarState extends State<SmileyRatingBar> {
         child: ListView.builder(
             shrinkWrap: true,
             scrollDirection: Axis.horizontal,
-            itemCount: widget.counter,
+            itemCount: widget.ids.length,
             itemBuilder: (context, index) {
               return GestureDetector(
                   onTap: () {

--- a/lib/use_cases/create_response_use_case.dart
+++ b/lib/use_cases/create_response_use_case.dart
@@ -40,6 +40,11 @@ class ResponseInput {
   Map<String, List<AnswerDetail>> questionsAndAnswers = {};
 
   ResponseInput(this.surveyId);
+
+  @override
+  String toString() {
+    return "ResponseInput: SurveyId: $surveyId - $questionsAndAnswers";
+  }
 }
 
 class AnswerDetail {
@@ -47,4 +52,9 @@ class AnswerDetail {
   String answer;
 
   AnswerDetail(this.id, this.answer);
+
+  @override
+  String toString() {
+    return "AnswerDetail: {$id:$answer}";
+  }
 }


### PR DESCRIPTION
Part of #23 

## What happened 👀

Handle the data submission from the Rating widget.
 
## Insight 📝
- In this PR, I submit the selected choice of those common SlideRatingBar, SmileyRate, NPS, multi-choice widget back to the `SurveyController`.
- The logic will be simply as: submitting the answer back to the Controller - Controller record the answer with the `currentQuestion`'s `id`.  
- Remember to preselect the default value for some widget.
- Change to Stateful widget for some cases.
- Update data structure on the way we want to pass not only the `text` but also the `id` to submit back to the API later.

- Next PR: handle the text field & text area. 

## Proof Of Work 📹
Navigate through each question, you can see the selected answer printed out:

https://user-images.githubusercontent.com/13435717/126215842-15da35fb-50c9-4205-933e-9e2e0c1b0328.mov

