### PR TITLE
#26 Implement cacheFirst data with Hive

### DIFF
--- a/lib/api/graphql/graphql_client_provider.dart
+++ b/lib/api/graphql/graphql_client_provider.dart
@@ -32,7 +32,7 @@ class GraphQLClientProvider {
         _allLink = _httpLink;
       }
       _client = GraphQLClient(
-        cache: GraphQLCache(),
+        cache: GraphQLCache(store: HiveStore()),
         link: _allLink,
       );
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:get/get.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:survey/api/graphql/graphql_client_provider.dart';
 import 'package:survey/api/http/api_client_provider.dart';
 import 'package:survey/navigator/navigator.dart';
@@ -81,6 +82,7 @@ class _AppState extends State<SurveyApp> {
   }
 
   void _initAppDependencies() {
+    initHiveForFlutter();
     Get.put<SharedPreferencesStorage>(LocalSharedPreferencesStorage());
     Get.put<ApiClient>(ApiClientProvider().httpClient());
     Get.put<GraphQLClientProvider>(GraphQLClientProvider());

--- a/lib/repositories/survey_repository.dart
+++ b/lib/repositories/survey_repository.dart
@@ -22,7 +22,7 @@ class SurveyRepositoryImpl implements SurveyRepository {
   @override
   Future<List<Survey>> getSurveys(String cursor) {
     final queryOptions = QueryOptions(
-        fetchPolicy: FetchPolicy.cacheAndNetwork,
+        fetchPolicy: FetchPolicy.cacheFirst,
         document: gql(GET_SURVEYS_QUERY),
         variables: {'endCursor': cursor});
     return _graphQlClient.query(queryOptions).then((value) {

--- a/lib/repositories/user_repository.dart
+++ b/lib/repositories/user_repository.dart
@@ -16,7 +16,7 @@ class UserRepositoryImpl implements UserRepository {
   @override
   Future<User> getProfile() async {
     final queryOptions = QueryOptions(
-      fetchPolicy: FetchPolicy.cacheAndNetwork,
+      fetchPolicy: FetchPolicy.cacheFirst,
       document: gql(GET_PROFILE_QUERY),
     );
     return _graphQlClient.query(queryOptions).then((value) {


### PR DESCRIPTION
Closes #26 

## What happened 👀

Setup the db (Hive) for data persistence to the disk.
 
## Insight 📝

- The `graphql_flutter` package supports this out-of-the-box. It handles all the DAO, HiveDb interactions for us.
- Setup the `getSurveys` and `getProfile` to returns `cacheFirst` data - it doesn't merge any further data from the network as the API responds too fast and it creates still a small delay during the data merging (cache data vs network data).
- The strategy is that we serve the cache data first so it's fast for the content display; then we will allow the Pull To Refresh to force content reloading later.
- Also, Offline support. 

## Proof Of Work 📹
As you can see, the data is served really fast (instantly) when restarting the application:

https://user-images.githubusercontent.com/13435717/128491356-18a3c7f2-6651-4a3a-9e68-c2c3e3310017.mp4


When offline: cached data + cached image still can render: 🤑 

https://user-images.githubusercontent.com/13435717/128497787-2938b9c6-094d-4ae6-9f20-f9de9c72f1e1.mov


