### PR TITLE
[Chore] Add User Repository unit test

### DIFF
--- a/lib/api/graphql/graphql_client_provider.dart
+++ b/lib/api/graphql/graphql_client_provider.dart
@@ -49,7 +49,7 @@ class GraphQLClientProvider {
       shouldRefresh: (response) {
         var hasAuthError = response.errors != null &&
             response.errors.any((element) =>
-            element.extensions['code'] == CODE_INVALID_OR_EXPIRED_TOKEN);
+                element.extensions['code'] == CODE_INVALID_OR_EXPIRED_TOKEN);
         return hasAuthError;
       },
       doRefreshToken: (oauth2Token) async {

--- a/lib/api/graphql/graphql_client_provider.dart
+++ b/lib/api/graphql/graphql_client_provider.dart
@@ -1,3 +1,4 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:fresh_graphql/fresh_graphql.dart';
 import 'package:get/get.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
@@ -17,7 +18,8 @@ class GraphQLClientProvider {
   static CustomAuthLink _customAuthLink;
   static GraphQLClient _client;
 
-  factory GraphQLClientProvider() {
+  factory GraphQLClientProvider({@nullable GraphQLClient injectedClient}) {
+    _client = injectedClient;
     return GraphQLClientProvider._(
       HttpLink(F.graphQLEndpoint),
     );
@@ -47,7 +49,7 @@ class GraphQLClientProvider {
       shouldRefresh: (response) {
         var hasAuthError = response.errors != null &&
             response.errors.any((element) =>
-                element.extensions['code'] == CODE_INVALID_OR_EXPIRED_TOKEN);
+            element.extensions['code'] == CODE_INVALID_OR_EXPIRED_TOKEN);
         return hasAuthError;
       },
       doRefreshToken: (oauth2Token) async {

--- a/test/fakers/fake_shared_preferences_storage.dart
+++ b/test/fakers/fake_shared_preferences_storage.dart
@@ -26,4 +26,9 @@ class FakeSharedPreferencesStorage extends Fake
   Future<void> saveRefreshToken(String refreshToken) async {
     _fakeStorage['refresh-token'] = refreshToken;
   }
+
+  @override
+  Future<String> getRefreshToken() async {
+    return _fakeStorage['refresh-token'];
+  }
 }

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -1,8 +1,9 @@
+import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:mockito/annotations.dart';
 import 'package:survey/repositories/oauth_repository.dart';
 import 'package:survey/repositories/user_repository.dart';
 
-@GenerateMocks([UserRepository, OAuthRepository])
+@GenerateMocks([UserRepository, OAuthRepository, GraphQLClient])
 main() {
   // empty class to generate mock repository classes
 }

--- a/test/mocks/generate_mocks.mocks.dart
+++ b/test/mocks/generate_mocks.mocks.dart
@@ -1,3 +1,4 @@
+import 'package:graphql/src/graphql_client.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:survey/repositories/oauth_repository.dart' as _i3;
 import 'package:survey/repositories/user_repository.dart' as _i2;
@@ -16,6 +17,15 @@ class MockUserRepository extends _i1.Mock implements _i2.UserRepository {
 /// See the documentation for Mockito's code generation for more information.
 class MockOAuthRepository extends _i1.Mock implements _i3.OAuthRepository {
   MockOAuthRepository() {
+    _i1.throwOnMissingStub(this);
+  }
+}
+
+/// A class which mocks [GraphQLClient].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockGraphQLClient extends _i1.Mock implements _i4.GraphQLClient {
+  MockGraphQLClient() {
     _i1.throwOnMissingStub(this);
   }
 }

--- a/test/repositories/user_repository_test.dart
+++ b/test/repositories/user_repository_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey/api/graphql/graphql_client_provider.dart';
+import 'package:survey/exception/network_exceptions.dart';
+import 'package:survey/models/user.dart';
+import 'package:survey/repositories/user_repository.dart';
+
+import '../fakers/fake_shared_preferences_storage.dart';
+import '../mocks/generate_mocks.mocks.dart';
+
+main() {
+  final mockClient = MockGraphQLClient();
+  final graphqlClientProvider =
+      GraphQLClientProvider(injectedClient: mockClient);
+  final fakeSharedPref = FakeSharedPreferencesStorage();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final testedUserRepository =
+      UserRepositoryImpl(graphqlClientProvider, fakeSharedPref);
+
+  group('Validate getProfile', () {
+    test('When get Profile successfully, it returns User data', () async {
+      when(mockClient.query(any))
+          .thenAnswer((_) async => QueryResult.optimistic(data: {
+                "profile": {
+                  "id": "mock id",
+                  "email": "mock email",
+                  "avatarUrl": "mock url",
+                },
+              }));
+
+      final profile = await testedUserRepository.getProfile();
+
+      expect(profile, isA<User>());
+      expect(profile.id, "mock id");
+      expect(profile.email, "mock email");
+      expect(profile.avatarUrl, "mock url");
+    });
+
+    test('When get Profile unsuccessfully, it returns NetworkExceptions',
+        () async {
+      when(mockClient.query(any))
+          .thenAnswer((_) async => QueryResult.optimistic(data: null));
+      expect(() => testedUserRepository.getProfile(),
+          throwsA(isA<NetworkExceptions>()));
+    });
+  });
+
+  group('Validate isLoggedIn', () {
+    test('When the user has logged in, it returns corresponding status',
+        () async {
+      fakeSharedPref.saveRefreshToken("fake refreshToken");
+      final result = await testedUserRepository.isLoggedIn();
+      expect(result, true);
+
+      // FIXME: somehow I cannot separate this to another test/group, it fails the test mysteriously
+      fakeSharedPref.saveRefreshToken("");
+      final negativeResult = await testedUserRepository.isLoggedIn();
+      expect(negativeResult, false);
+    });
+  });
+}

--- a/test/use_cases/get_login_state_use_case_test.dart
+++ b/test/use_cases/get_login_state_use_case_test.dart
@@ -3,7 +3,7 @@ import 'package:survey/use_cases/base_use_case.dart';
 import 'package:survey/use_cases/get_login_state_use_case.dart';
 import 'package:test/test.dart';
 
-import '../mocks/repository_mocks.mocks.dart';
+import '../mocks/generate_mocks.mocks.dart';
 
 void main() {
   group('Validate logged-in case', () {

--- a/test/use_cases/get_profile_use_case_test.dart
+++ b/test/use_cases/get_profile_use_case_test.dart
@@ -5,7 +5,7 @@ import 'package:survey/use_cases/base_use_case.dart';
 import 'package:survey/use_cases/get_profile_use_case.dart';
 import 'package:test/test.dart';
 
-import '../mocks/repository_mocks.mocks.dart';
+import '../mocks/generate_mocks.mocks.dart';
 
 void main() {
   group('Validate get profile success use case', () {

--- a/test/use_cases/login_use_case_test.dart
+++ b/test/use_cases/login_use_case_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 
 import '../fakers/fake_graphql_client_provider.dart';
 import '../fakers/fake_shared_preferences_storage.dart';
-import '../mocks/repository_mocks.mocks.dart';
+import '../mocks/generate_mocks.mocks.dart';
 
 void main() {
   group('Validate login use case', () {


### PR DESCRIPTION
## What happened 👀

Add unit test to the next level: Repository
 
## Insight 📝

- Renamed the generated mock class set up to be more generic.
- Allow injecting a GraphQLClient when initialized to inject the mock client component - which manipulates the query response when needed.
- Setup the mock response and test the 2 methods that invoke to get data, parse the response accordingly.

## Proof Of Work 📹
Codecov will ++++
