### PR TITLE
[Chore] Unit test on SurveyRepo > createResponse

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         run: flutter test --machine --coverage
 
       - name: Setup lcov and modify the reports
-        run: sudo apt-get install lcov && lcov --remove coverage/lcov.info 'lib/*/*.freezed.dart' 'lib/*/*.g.dart' 'lib/generated/*.dart' 'lib/flavors.dart' -o coverage/lcov.info
+        run: sudo apt-get install lcov && lcov --remove coverage/lcov.info 'lib/*/*.freezed.dart' 'lib/*/*.g.dart' 'lib/generated/*.dart' 'lib/flavors.dart' 'lib/exception/network_exceptions.dart' -o coverage/lcov.info
 
       - uses: codecov/codecov-action@v2
         with:

--- a/lib/repositories/survey_repository.dart
+++ b/lib/repositories/survey_repository.dart
@@ -63,6 +63,10 @@ class SurveyRepositoryImpl implements SurveyRepository {
         document: gql(CREATE_RESPONSE),
         variables: {'input': input});
 
-    return _graphQlClient.mutate(mutationOption);
+    try {
+      return _graphQlClient.mutate(mutationOption);
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
   }
 }

--- a/test/repositories/survey_repository_test.dart
+++ b/test/repositories/survey_repository_test.dart
@@ -71,7 +71,7 @@ main() async {
 
     test('When getSurveyById successfully, it returns a Survey', () async {
       when(mockGraphQLClient.query(any)).thenAnswer(
-            (_) async => graphql.QueryResult.optimistic(
+        (_) async => graphql.QueryResult.optimistic(
           data: singleSurveyData,
         ),
       );

--- a/test/repositories/survey_repository_test.dart
+++ b/test/repositories/survey_repository_test.dart
@@ -84,7 +84,7 @@ main() async {
 
     test('When get Survey successfully, it has added extra data', () async {
       when(mockGraphQLClient.query(any)).thenAnswer(
-            (_) async => graphql.QueryResult.optimistic(
+        (_) async => graphql.QueryResult.optimistic(
           data: singleSurveyData,
         ),
       );

--- a/test/repositories/survey_repository_test.dart
+++ b/test/repositories/survey_repository_test.dart
@@ -98,7 +98,7 @@ main() async {
 
     test('When getSurveyById failed, it throws a NetworkException-NotFound',
         () async {
-          when(mockGraphQLClient.query(any))
+      when(mockGraphQLClient.query(any))
           .thenAnswer((_) async => graphql.QueryResult.optimistic(data: null));
 
       expect(() => testedSurveyRepository.getSurveyById("any"),

--- a/test/repositories/survey_repository_test.dart
+++ b/test/repositories/survey_repository_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:mockito/mockito.dart';
+import 'package:survey/api/graphql/mutation/create_response_mutation_input.dart';
 import 'package:survey/exception/network_exceptions.dart';
 import 'package:survey/models/survey.dart';
 import 'package:survey/repositories/survey_repository.dart';
@@ -101,6 +102,31 @@ main() async {
 
       expect(() => testedSurveyRepository.getSurveyById("any"),
           throwsA(isA<NotFound>()));
+    });
+  });
+
+  group('Validate createResponse', () {
+    final testedSurveyRepository = SurveyRepositoryImpl(mockGraphQLClient);
+    test('When createResponse successfully, it returns null', () {
+      when(mockGraphQLClient.mutate(any)).thenReturn(null);
+
+      final testInput = CreateResponseMutationInput(null);
+
+      final result = testedSurveyRepository.createResponse(testInput);
+
+      expect(result, null);
+    });
+
+    test('When createResponse unsuccessfully, it throws NetworkException',
+        () async {
+      final error = NetworkExceptions.unauthorisedRequest();
+      when(mockGraphQLClient.mutate(any))
+          .thenAnswer((_) => Future.error(error));
+
+      final testInput = CreateResponseMutationInput(null);
+
+      expect(() async => testedSurveyRepository.createResponse(testInput),
+          throwsA(isA<UnauthorisedRequest>()));
     });
   });
 }

--- a/test/repositories/survey_repository_test.dart
+++ b/test/repositories/survey_repository_test.dart
@@ -54,7 +54,7 @@ main() async {
 
     test('When get Surveys failed, it throws a NetworkException-NotFound',
         () async {
-          when(mockGraphQLClient.query(any))
+      when(mockGraphQLClient.query(any))
           .thenAnswer((_) async => graphql.QueryResult.optimistic(data: null));
 
       expect(() => testedSurveyRepository.getSurveys("", true),


### PR DESCRIPTION
## What happened 👀

Continue to add more unit test coverage SurveyRepository > createResponse

## Insight 📝

- Refactor code to handle the error case - we must wrap the DioError (lower level) to the app level Error (NetworkError).
- Adding unit test for 2 paths accordingly
 
## Proof Of Work 📹
Code cov ++