### PR TITLE
[Chore] Add UserManager unit test

### DIFF
--- a/test/managers/user_manager_test.dart
+++ b/test/managers/user_manager_test.dart
@@ -1,0 +1,41 @@
+import 'package:get/get.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey/managers/user_manager.dart';
+import 'package:survey/models/user.dart';
+import 'package:survey/use_cases/base_use_case.dart';
+import 'package:survey/use_cases/get_profile_use_case.dart';
+import 'package:test/test.dart';
+
+import '../mocks/generate_mocks.mocks.dart';
+
+main() {
+  final mockGetProfileUseCase = MockGetProfileUseCase();
+  Get.put<GetProfileUseCase>(mockGetProfileUseCase);
+  final testedUserManager = UserManagerImpl();
+
+  group('Validate UserManager behavior', () {
+    when(mockGetProfileUseCase.call())
+        .thenAnswer((_) async => Success(User(id: "123")));
+
+    test(
+        'When freshly started, it returns a User with id -1, then refresh value',
+        () async {
+      final userObs = testedUserManager.getCurrentUser();
+      expect(userObs.value.id, "-1");
+
+      // According to the implementation of getCurrentUser(), it calls refresh() and emit 1 more time
+      final secondUserValue = await userObs.stream.first;
+      expect(secondUserValue.id, "123");
+    });
+
+    test('When refresh is called, it returns the latest profile', () async {
+      when(mockGetProfileUseCase.call())
+          .thenAnswer((_) async => Success(User(id: "1234")));
+
+      testedUserManager.refresh();
+
+      final result = await testedUserManager.getCurrentUser().stream.first;
+      expect(result.id, "1234");
+    });
+  });
+}

--- a/test/managers/user_manager_test.dart
+++ b/test/managers/user_manager_test.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 import 'package:mockito/mockito.dart';
+import 'package:survey/exception/network_exceptions.dart';
 import 'package:survey/managers/user_manager.dart';
 import 'package:survey/models/user.dart';
 import 'package:survey/use_cases/base_use_case.dart';
@@ -36,6 +37,15 @@ main() {
 
       final result = await testedUserManager.getCurrentUser().stream.first;
       expect(result.id, "1234");
+    });
+
+    test('When refresh unsuccessfully, it emits User(ERROR)', () async {
+      when(mockGetProfileUseCase.call()).thenAnswer((_) async =>
+          Failed(UseCaseException(NetworkExceptions.badRequest(), null)));
+
+      testedUserManager.refresh();
+      final result = await testedUserManager.getCurrentUser().stream.first;
+      expect(result.id, ERROR);
     });
   });
 }

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -2,8 +2,10 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:mockito/annotations.dart';
 import 'package:survey/repositories/oauth_repository.dart';
 import 'package:survey/repositories/user_repository.dart';
+import 'package:survey/use_cases/get_profile_use_case.dart';
 
-@GenerateMocks([UserRepository, OAuthRepository, GraphQLClient])
+@GenerateMocks(
+    [UserRepository, OAuthRepository, GraphQLClient, GetProfileUseCase])
 main() {
   // empty class to generate mock repository classes
 }

--- a/test/mocks/generate_mocks.mocks.dart
+++ b/test/mocks/generate_mocks.mocks.dart
@@ -2,6 +2,7 @@ import 'package:graphql/src/graphql_client.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:survey/repositories/oauth_repository.dart' as _i3;
 import 'package:survey/repositories/user_repository.dart' as _i2;
+import 'package:survey/use_cases/get_profile_use_case.dart' as _i5;
 
 /// A class which mocks [UserRepository].
 ///
@@ -26,6 +27,15 @@ class MockOAuthRepository extends _i1.Mock implements _i3.OAuthRepository {
 /// See the documentation for Mockito's code generation for more information.
 class MockGraphQLClient extends _i1.Mock implements _i4.GraphQLClient {
   MockGraphQLClient() {
+    _i1.throwOnMissingStub(this);
+  }
+}
+
+/// A class which mocks [GetProfileUseCase].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockGetProfileUseCase extends _i1.Mock implements _i5.GetProfileUseCase {
+  MockGetProfileUseCase() {
     _i1.throwOnMissingStub(this);
   }
 }


### PR DESCRIPTION
## What happened 👀
Add unit test for UserManager
 
## Insight 📝
- Learning how to test with RxObs in Flutter (from GetX package).
- Testing the `currentUserProfile` emission: default, positive, negative, refresh value. 
 
## Proof Of Work 📹

Codecov ++