### PR TITLE
[Chore] Add unit test for http api client - login

### DIFF
--- a/lib/api/http/api_client_provider.dart
+++ b/lib/api/http/api_client_provider.dart
@@ -23,6 +23,12 @@ class ApiClientProvider {
     return ApiClientProvider._(dio);
   }
 
+  // A utility method for unit testing, developers can alter the response as expected
+  @visibleForTesting
+  void injectHttpClientAdapter(HttpClientAdapter httpClientAdapter) {
+    _dio.httpClientAdapter = httpClientAdapter;
+  }
+
   ApiClient httpClient() {
     return ApiClient(_dio, baseUrl: F.restApiEndpoint);
   }

--- a/test/api/http/api_client_test.dart
+++ b/test/api/http/api_client_test.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey/api/http/api_client_provider.dart';
+import 'package:survey/api/http/request/oauth_token_request.dart';
+import 'package:survey/api/http/response/auth_token_response.dart';
+
+import '../../mocks/generate_mocks.mocks.dart';
+
+main() {
+  group('Validate http ApiClient', () {
+    final testedApiClientProvider = ApiClientProvider();
+    final mockHttpClientAdapter = MockHttpClientAdapter();
+
+    testedApiClientProvider.injectHttpClientAdapter(mockHttpClientAdapter);
+
+    final testedHttpApiClient = testedApiClientProvider.httpClient();
+
+    test('When login successfully, it returns AuthTokenResponseData', () async {
+      final oauthJsonFile = File('test/test_resources/oauth.json');
+
+      final fakeHttpResponse = ResponseBody.fromString(
+        oauthJsonFile.readAsStringSync(),
+        200,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      );
+      when(mockHttpClientAdapter.fetch(any, any, any))
+          .thenAnswer((_) async => fakeHttpResponse);
+
+      // Use fromJson for more test coverage
+      final result =
+          await testedHttpApiClient.login(OAuthTokenRequest.fromJson({
+        'grant_type': 'password',
+        'email': 'any',
+        'password': 'password',
+        'client_id': 'client_id',
+        'client_secret': 'client_secret'
+      }));
+
+      expect(result, isA<AuthTokenResponseData>());
+      expect(result.data.type, 'token');
+      expect(result.data.authToken.accessToken, 'access token');
+    });
+
+    test('When login unsuccessfully, it returns DioError', () async {
+      final oauthJsonFile = File('test/test_resources/oauth_error.json');
+
+      final fakeHttpResponse = ResponseBody.fromString(
+        oauthJsonFile.readAsStringSync(),
+        400,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      );
+      when(mockHttpClientAdapter.fetch(any, any, any))
+          .thenAnswer((_) async => fakeHttpResponse);
+
+      final result =
+          () => testedHttpApiClient.login(OAuthTokenRequest.fromJson({
+                'grant_type': 'password',
+                'email': 'any',
+                'password': 'failed password',
+                'client_id': 'client_id',
+                'client_secret': 'client_secret'
+              }));
+
+      expect(result, throwsA(isA<DioError>()));
+    });
+  });
+}

--- a/test/api/http/api_client_test.dart
+++ b/test/api/http/api_client_test.dart
@@ -10,14 +10,13 @@ import 'package:survey/api/http/response/auth_token_response.dart';
 import '../../mocks/generate_mocks.mocks.dart';
 
 main() {
-  group('Validate http ApiClient', () {
-    final testedApiClientProvider = ApiClientProvider();
-    final mockHttpClientAdapter = MockHttpClientAdapter();
+  final testedApiClientProvider = ApiClientProvider();
+  final mockHttpClientAdapter = MockHttpClientAdapter();
+  testedApiClientProvider.injectHttpClientAdapter(mockHttpClientAdapter);
 
-    testedApiClientProvider.injectHttpClientAdapter(mockHttpClientAdapter);
+  final testedHttpApiClient = testedApiClientProvider.httpClient();
 
-    final testedHttpApiClient = testedApiClientProvider.httpClient();
-
+  group('Validate http ApiClient - login', () {
     test('When login successfully, it returns AuthTokenResponseData', () async {
       final oauthJsonFile = File('test/test_resources/oauth.json');
 
@@ -33,7 +32,7 @@ main() {
 
       // Use fromJson for more test coverage
       final result =
-          await testedHttpApiClient.login(OAuthTokenRequest.fromJson({
+      await testedHttpApiClient.login(OAuthTokenRequest.fromJson({
         'grant_type': 'password',
         'email': 'any',
         'password': 'password',
@@ -68,7 +67,8 @@ main() {
                 'client_secret': 'client_secret'
               }));
 
-      expect(result, throwsA(isA<DioError>()));
+      expect(result,
+          throwsA(predicate<DioError>((ex) => ex.response.statusCode == 400)));
     });
   });
 }

--- a/test/api/http/api_client_test.dart
+++ b/test/api/http/api_client_test.dart
@@ -32,7 +32,7 @@ main() {
 
       // Use fromJson for more test coverage
       final result =
-      await testedHttpApiClient.login(OAuthTokenRequest.fromJson({
+          await testedHttpApiClient.login(OAuthTokenRequest.fromJson({
         'grant_type': 'password',
         'email': 'any',
         'password': 'password',

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:mockito/annotations.dart';
 import 'package:survey/api/http/api_client.dart';
@@ -10,7 +11,8 @@ import 'package:survey/use_cases/get_profile_use_case.dart';
   OAuthRepository,
   GraphQLClient,
   GetProfileUseCase,
-  ApiClient
+  ApiClient,
+  HttpClientAdapter
 ])
 main() {
   // empty class to generate mock repository classes

--- a/test/mocks/generate_mocks.mocks.dart
+++ b/test/mocks/generate_mocks.mocks.dart
@@ -1,3 +1,4 @@
+import 'package:dio/src/adapter.dart' as _i7;
 import 'package:graphql/src/graphql_client.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:survey/api/http/api_client.dart' as _i6;
@@ -46,6 +47,15 @@ class MockGetProfileUseCase extends _i1.Mock implements _i5.GetProfileUseCase {
 /// See the documentation for Mockito's code generation for more information.
 class MockApiClient extends _i1.Mock implements _i6.ApiClient {
   MockApiClient() {
+    _i1.throwOnMissingStub(this);
+  }
+}
+
+/// A class which mocks [HttpClientAdapter].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockHttpClientAdapter extends _i1.Mock implements _i7.HttpClientAdapter {
+  MockHttpClientAdapter() {
     _i1.throwOnMissingStub(this);
   }
 }

--- a/test/test_resources/oauth_error.json
+++ b/test/test_resources/oauth_error.json
@@ -1,0 +1,11 @@
+{
+  "errors": [
+    {
+      "source": {
+        "parameter": "OAuth::Error"
+      },
+      "detail": "failed",
+      "code": "invalid_grant"
+    }
+  ]
+}


### PR DESCRIPTION
## What happened 👀

Start to add unit test at the ApiClient - network level.
 
## Insight 📝

- Add @visibleForTesting method to inject a test behavior.
- Insert mock response, alter response body.
- Test the behavior when using HttpClient() from HttpClientProvider (HTTP API) when calling to `login()` on success/failed case.
 
## Proof Of Work 📹
💁‍♂️  codecov++
<img src="https://user-images.githubusercontent.com/13435717/133378195-4857f121-b61e-4ed6-95b0-e467e9e92c39.png" width=500/>

