### PR TITLE
[Chore] Add unit test for http api client - refreshToken

### DIFF
--- a/test/api/http/api_client_test.dart
+++ b/test/api/http/api_client_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:survey/api/http/api_client_provider.dart';
 import 'package:survey/api/http/request/oauth_token_request.dart';
+import 'package:survey/api/http/request/refresh_token_request.dart';
 import 'package:survey/api/http/response/auth_token_response.dart';
 
 import '../../mocks/generate_mocks.mocks.dart';
@@ -69,6 +70,61 @@ main() {
 
       expect(result,
           throwsA(predicate<DioError>((ex) => ex.response.statusCode == 400)));
+    });
+
+    test('When refresh token successfully, it returns AuthTokenResponseData',
+        () async {
+      final oauthJsonFile = File('test/test_resources/oauth.json');
+
+      final fakeHttpResponse = ResponseBody.fromString(
+        oauthJsonFile.readAsStringSync(),
+        200,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      );
+      when(mockHttpClientAdapter.fetch(any, any, any))
+          .thenAnswer((_) async => fakeHttpResponse);
+
+      // Use fromJson for more test coverage
+      final result =
+          await testedHttpApiClient.refreshToken(RefreshTokenRequest.fromJson({
+        'grant_type': 'refresh',
+        'refresh': 'refresh_token',
+        'client_id': 'client_id',
+        'client_secret': 'client_secret'
+      }));
+
+      expect(result, isA<AuthTokenResponseData>());
+      expect(result.data.type, 'token');
+      expect(result.data.authToken.accessToken, 'access token');
+    });
+
+    test('When refresh token unsuccessfully, it returns DioError', () async {
+      final oauthJsonFile = File('test/test_resources/oauth_error.json');
+
+      final fakeHttpResponse = ResponseBody.fromString(
+        oauthJsonFile.readAsStringSync(),
+        401,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      );
+      when(mockHttpClientAdapter.fetch(any, any, any))
+          .thenAnswer((_) async => fakeHttpResponse);
+
+      final result =
+          () => testedHttpApiClient.refreshToken(RefreshTokenRequest.fromJson({
+                'grant_type': 'refresh',
+                'refresh_token': 'failed refresh_token',
+                'client_id': 'client_id',
+                'client_secret': 'client_secret'
+              }));
+
+      expect(
+          result,
+          throwsA(predicate(
+              (ex) => ex is DioError && ex.response.statusCode == 401)));
     });
   });
 }

--- a/test/api/http/api_client_test.dart
+++ b/test/api/http/api_client_test.dart
@@ -71,7 +71,9 @@ main() {
       expect(result,
           throwsA(predicate<DioError>((ex) => ex.response.statusCode == 400)));
     });
+  });
 
+  group('Validate http ApiClient - refresh token', () {
     test('When refresh token successfully, it returns AuthTokenResponseData',
         () async {
       final oauthJsonFile = File('test/test_resources/oauth.json');
@@ -83,22 +85,22 @@ main() {
           Headers.contentTypeHeader: [Headers.jsonContentType],
         },
       );
-      when(mockHttpClientAdapter.fetch(any, any, any))
-          .thenAnswer((_) async => fakeHttpResponse);
+          when(mockHttpClientAdapter.fetch(any, any, any))
+              .thenAnswer((_) async => fakeHttpResponse);
 
-      // Use fromJson for more test coverage
-      final result =
+          // Use fromJson for more test coverage
+          final result =
           await testedHttpApiClient.refreshToken(RefreshTokenRequest.fromJson({
-        'grant_type': 'refresh',
-        'refresh': 'refresh_token',
-        'client_id': 'client_id',
-        'client_secret': 'client_secret'
-      }));
+            'grant_type': 'refresh',
+            'refresh': 'refresh_token',
+            'client_id': 'client_id',
+            'client_secret': 'client_secret'
+          }));
 
-      expect(result, isA<AuthTokenResponseData>());
-      expect(result.data.type, 'token');
-      expect(result.data.authToken.accessToken, 'access token');
-    });
+          expect(result, isA<AuthTokenResponseData>());
+          expect(result.data.type, 'token');
+          expect(result.data.authToken.accessToken, 'access token');
+        });
 
     test('When refresh token unsuccessfully, it returns DioError', () async {
       final oauthJsonFile = File('test/test_resources/oauth_error.json');
@@ -121,10 +123,8 @@ main() {
                 'client_secret': 'client_secret'
               }));
 
-      expect(
-          result,
-          throwsA(predicate(
-              (ex) => ex is DioError && ex.response.statusCode == 401)));
+      expect(result,
+          throwsA(predicate<DioError>((ex) => ex.response.statusCode == 401)));
     });
   });
 }

--- a/test/api/http/api_client_test.dart
+++ b/test/api/http/api_client_test.dart
@@ -85,22 +85,22 @@ main() {
           Headers.contentTypeHeader: [Headers.jsonContentType],
         },
       );
-          when(mockHttpClientAdapter.fetch(any, any, any))
-              .thenAnswer((_) async => fakeHttpResponse);
+      when(mockHttpClientAdapter.fetch(any, any, any))
+          .thenAnswer((_) async => fakeHttpResponse);
 
-          // Use fromJson for more test coverage
-          final result =
+      // Use fromJson for more test coverage
+      final result =
           await testedHttpApiClient.refreshToken(RefreshTokenRequest.fromJson({
-            'grant_type': 'refresh',
-            'refresh': 'refresh_token',
-            'client_id': 'client_id',
-            'client_secret': 'client_secret'
-          }));
+        'grant_type': 'refresh',
+        'refresh': 'refresh_token',
+        'client_id': 'client_id',
+        'client_secret': 'client_secret'
+      }));
 
-          expect(result, isA<AuthTokenResponseData>());
-          expect(result.data.type, 'token');
-          expect(result.data.authToken.accessToken, 'access token');
-        });
+      expect(result, isA<AuthTokenResponseData>());
+      expect(result.data.type, 'token');
+      expect(result.data.authToken.accessToken, 'access token');
+    });
 
     test('When refresh token unsuccessfully, it returns DioError', () async {
       final oauthJsonFile = File('test/test_resources/oauth_error.json');


### PR DESCRIPTION
## What happened 👀

Continue adding unit test to HTTP ApiClient - `refreshToken()`
 
## Insight 📝

- Restructuring the test group.
- Adding test cases for Api testing: `refreshToken()` in both success and failed case.
 
## Proof Of Work 📹
Codecov ++ 🤑 
