### PR TITLE
[Chore] Add super to onClose() method

### DIFF
--- a/lib/pages/login/login_controller.dart
+++ b/lib/pages/login/login_controller.dart
@@ -32,5 +32,6 @@ class LoginController extends GetxController {
   void onClose() {
     emailController.dispose();
     passwordController.dispose();
+    super.onClose();
   }
 }

--- a/test/pages/login/login_controller_test.dart
+++ b/test/pages/login/login_controller_test.dart
@@ -54,9 +54,9 @@ void main() {
       Get.delete<LoginController>(); // onClose() will be invoked
 
       // All the TextEditingListener will no be usable anymore, an error will throw if we try to
-      expect(() => loginController.emailController.hasListeners,
+      expect(() => loginController.emailController.clear(),
           throwsA(isA<FlutterError>()));
-      expect(() => loginController.passwordController.hasListeners,
+      expect(() => loginController.passwordController.clear(),
           throwsA(isA<FlutterError>()));
 
       expect(loginController.hasListeners, false);

--- a/test/pages/login/login_controller_test.dart
+++ b/test/pages/login/login_controller_test.dart
@@ -46,6 +46,7 @@ void main() {
 
       expect(onFailedCalled, true);
       expect(loginController.isLoading.value, false);
+      loginController.onClose();
     });
   });
 }

--- a/test/pages/login/login_controller_test.dart
+++ b/test/pages/login/login_controller_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:mockito/annotations.dart';
@@ -16,7 +17,8 @@ void main() {
 
   group('Validate login controller login action', () {
     final mockLoginUseCase = MockLoginUseCase();
-    final loginController = LoginController();
+    Get.lazyPut(() => LoginController());
+    final loginController = Get.find<LoginController>();
     Get.lazyPut<LoginUseCase>(() => mockLoginUseCase);
 
     loginController.emailController.text = 'hello';
@@ -46,7 +48,18 @@ void main() {
 
       expect(onFailedCalled, true);
       expect(loginController.isLoading.value, false);
-      loginController.onClose();
+    });
+
+    test('When LoginController deleted, it invokes onClose()', () {
+      Get.delete<LoginController>(); // onClose() will be invoked
+
+      // All the TextEditingListener will no be usable anymore, an error will throw if we try to
+      expect(() => loginController.emailController.hasListeners,
+          throwsA(isA<FlutterError>()));
+      expect(() => loginController.passwordController.hasListeners,
+          throwsA(isA<FlutterError>()));
+
+      expect(loginController.hasListeners, false);
     });
   });
 }


### PR DESCRIPTION
## What happened 👀

Minor: to ensure that the test coverage runs through all methods inside `login_controller`
 
## Insight 📝
- Add `super();` call.
- Invoke `onClose()` when testing by running throw a GetxController lifecycle: put/delete
 
## Proof Of Work 📹

Code cov ++
