### PR TITLE
[Chore] Add graphql client unit test

### DIFF
--- a/lib/api/graphql/graphql_client_provider.dart
+++ b/lib/api/graphql/graphql_client_provider.dart
@@ -5,8 +5,7 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:survey/api/graphql/const.dart';
 import 'package:survey/api/graphql/link/custom_auth_link.dart';
 import 'package:survey/api/http/api_client.dart';
-import 'package:survey/api/http/request/refresh_token_request.dart';
-import 'package:survey/preferences/shared_preferences.dart';
+import 'package:survey/repositories/oauth_repository.dart';
 
 import '../../flavors.dart';
 
@@ -33,8 +32,10 @@ class GraphQLClientProvider {
       } else {
         _allLink = _httpLink;
       }
+
+      final cacheStore = Get.find<Store>();
       _client = GraphQLClient(
-        cache: GraphQLCache(store: HiveStore()),
+        cache: GraphQLCache(store: cacheStore),
         link: _allLink,
       );
     }
@@ -44,8 +45,9 @@ class GraphQLClientProvider {
   /// Call this when you have already set up the token storage, the token header
   /// will be updated automatically
   void tokenIsReadyToUse() {
+    final tokenStorage = Get.find<TokenStorage<OAuth2Token>>();
     _customAuthLink = CustomAuthLink.oAuth2(
-      tokenStorage: LocalSharedPreferencesStorage(),
+      tokenStorage: tokenStorage,
       shouldRefresh: (response) {
         var hasAuthError = response.errors != null &&
             response.errors.any((element) =>
@@ -54,22 +56,15 @@ class GraphQLClientProvider {
       },
       doRefreshToken: (oauth2Token) async {
         final httpClient = Get.find<ApiClient>();
-        final refreshResult = await httpClient.refreshToken(
-          RefreshTokenRequest(
-            refreshToken: oauth2Token.refreshToken,
-            clientId: F.basicAuthClientId,
-            clientSecret: F.basicAuthClientSecret,
-          ),
-        );
+        final oauthRepositoryImpl = OAuthRepositoryImpl(httpClient);
+        final refreshResult =
+            await oauthRepositoryImpl.refreshToken(oauth2Token.refreshToken);
 
-        if (refreshResult.data == null) return null;
-
-        final tokenResponse = refreshResult.data.authToken;
         return OAuth2Token(
-          accessToken: tokenResponse.accessToken,
-          refreshToken: tokenResponse.refreshToken,
-          expiresIn: tokenResponse.expiresIn,
-          tokenType: tokenResponse.tokenType,
+          accessToken: refreshResult.accessToken,
+          refreshToken: refreshResult.refreshToken,
+          expiresIn: refreshResult.expiresIn,
+          tokenType: refreshResult.tokenType,
         );
       },
     );

--- a/lib/api/graphql/graphql_client_provider.dart
+++ b/lib/api/graphql/graphql_client_provider.dart
@@ -17,11 +17,15 @@ class GraphQLClientProvider {
   static CustomAuthLink _customAuthLink;
   static GraphQLClient _client;
 
-  factory GraphQLClientProvider({@nullable GraphQLClient injectedClient}) {
-    _client = injectedClient;
+  factory GraphQLClientProvider() {
     return GraphQLClientProvider._(
       HttpLink(F.graphQLEndpoint),
     );
+  }
+
+  @visibleForTesting
+  void setGraphQLClient(GraphQLClient injectedClient) {
+    _client = injectedClient;
   }
 
   GraphQLClient get client {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:fresh_graphql/fresh_graphql.dart';
 import 'package:get/get.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:survey/api/graphql/graphql_client_provider.dart';
@@ -83,8 +84,11 @@ class _AppState extends State<SurveyApp> {
   }
 
   void _initAppDependencies() {
-    initHiveForFlutter();
-    Get.put<SharedPreferencesStorage>(LocalSharedPreferencesStorage());
+    final localStorage = LocalSharedPreferencesStorage();
+    Get.put<SharedPreferencesStorage>(localStorage);
+    Get.put<TokenStorage<OAuth2Token>>(localStorage);
+    initHiveForFlutter().then((_) => Get.put<Store>(HiveStore()));
+
     Get.put<ApiClient>(ApiClientProvider().httpClient());
     Get.put<GraphQLClientProvider>(GraphQLClientProvider());
     Get.put<AppNavigator>(AppNavigatorImpl());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -87,7 +87,7 @@ class _AppState extends State<SurveyApp> {
     final localStorage = LocalSharedPreferencesStorage();
     Get.put<SharedPreferencesStorage>(localStorage);
     Get.put<TokenStorage<OAuth2Token>>(localStorage);
-    initHiveForFlutter().then((_) => Get.put<Store>(HiveStore()));
+    initHiveForFlutter().then((_) => Get.lazyPut<Store>(() => HiveStore()));
 
     Get.put<ApiClient>(ApiClientProvider().httpClient());
     Get.put<GraphQLClientProvider>(GraphQLClientProvider());

--- a/lib/repositories/oauth_repository.dart
+++ b/lib/repositories/oauth_repository.dart
@@ -47,7 +47,6 @@ class OAuthRepositoryImpl implements OAuthRepository {
           clientSecret: F.basicAuthClientSecret,
         ),
       );
-
       return response.data?.authToken;
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);

--- a/lib/repositories/oauth_repository.dart
+++ b/lib/repositories/oauth_repository.dart
@@ -1,11 +1,15 @@
 import 'package:survey/api/http/api_client.dart';
 import 'package:survey/api/http/request/oauth_token_request.dart';
+import 'package:survey/api/http/request/refresh_token_request.dart';
+import 'package:survey/api/http/response/auth_token_response.dart';
 import 'package:survey/exception/network_exceptions.dart';
 import 'package:survey/flavors.dart';
 import 'package:survey/models/auth_token.dart';
 
 abstract class OAuthRepository {
   Future<AuthToken> login(String email, String password);
+
+  Future<AuthTokenResponse> refreshToken(String refreshToken);
 }
 
 class OAuthRepositoryImpl implements OAuthRepository {
@@ -28,6 +32,23 @@ class OAuthRepositoryImpl implements OAuthRepository {
         refreshToken: authTokenResponse.refreshToken,
         expiresIn: authTokenResponse.expiresIn,
       );
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
+  }
+
+  @override
+  Future<AuthTokenResponse> refreshToken(String refreshToken) async {
+    try {
+      final response = await _restApiClient.refreshToken(
+        RefreshTokenRequest(
+          refreshToken: refreshToken,
+          clientId: F.basicAuthClientId,
+          clientSecret: F.basicAuthClientSecret,
+        ),
+      );
+
+      return response.data?.authToken;
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }

--- a/test/api/graphql/graphql_client_provider_test.dart
+++ b/test/api/graphql/graphql_client_provider_test.dart
@@ -48,9 +48,9 @@ main() {
       );
 
       final authenticatedClient = graphqlClientProvider.client;
-      final result = await authenticatedClient.query(queryOption);
-      print(result);
+      await authenticatedClient.query(queryOption);
       verify(mockApiClient.refreshToken(any)).called(1);
+      graphqlClientProvider.removeAuthToken();
     });
   });
 

--- a/test/api/graphql/graphql_client_provider_test.dart
+++ b/test/api/graphql/graphql_client_provider_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fresh_graphql/fresh_graphql.dart';
+import 'package:get/get.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey/api/graphql/graphql_client_provider.dart';
+import 'package:survey/api/graphql/query/surveys_query.dart';
+import 'package:survey/api/http/api_client.dart';
+import 'package:survey/api/http/response/auth_token_response.dart';
+
+import '../../fakers/fake_graphql_store.dart';
+import '../../fakers/fake_token_storage.dart';
+import '../../mocks/generate_mocks.mocks.dart';
+
+main() {
+  setUp(() {
+    Get.testMode = true;
+  });
+  final queryOption = QueryOptions(
+      fetchPolicy: FetchPolicy.networkOnly,
+      document: gql(GET_SURVEYS_QUERY),
+      variables: {'endCursor': ''});
+
+  Get.put<Store>(FakeStore());
+  final fakeTokenStorage = FakeTokenStorage();
+  Get.put<TokenStorage<OAuth2Token>>(fakeTokenStorage);
+  final mockApiClient = MockApiClient();
+  Get.put<ApiClient>(mockApiClient);
+
+  group('Validate GraphQLClient behaviors with invalid Authentication', () {
+    test(
+        'When making an unauthenticated request, it will try to refresh new token and retry',
+        () async {
+      final graphqlClientProvider = GraphQLClientProvider();
+      graphqlClientProvider.tokenIsReadyToUse();
+
+      when(mockApiClient.refreshToken(any)).thenAnswer(
+        (_) async => AuthTokenResponseData(
+          data: InnerResponseData.fromJson({
+            'attributes': {
+              'access_token': 'access_token',
+              'token_type': 'bearer',
+              'expires_in': 100,
+              'refresh_token': 'refresh_token',
+            }
+          }),
+        ),
+      );
+
+      final authenticatedClient = graphqlClientProvider.client;
+      final result = await authenticatedClient.query(queryOption);
+      print(result);
+      verify(mockApiClient.refreshToken(any)).called(1);
+    });
+  });
+
+  group('Validate GraphQLClient behaviors with Authentication', () {
+    final mockQueryManager = MockQueryManager();
+    when(mockQueryManager.query(any))
+        .thenAnswer((_) async => QueryResult.optimistic(
+              data: {'result': 'success'},
+            ));
+    test('When making a positive request, it returns data', () async {
+      final graphqlClientProvider = GraphQLClientProvider();
+      final client = graphqlClientProvider.client;
+      client.queryManager = mockQueryManager;
+
+      final result = await client.query(queryOption);
+
+      expect(result.data['result'], 'success');
+      expect(result.hasException, false);
+    });
+
+    test('When making an authenticated request, it returns data', () async {
+      final graphqlClientProvider = GraphQLClientProvider();
+      graphqlClientProvider.tokenIsReadyToUse();
+
+      final authenticatedClient = graphqlClientProvider.client;
+      authenticatedClient.queryManager = mockQueryManager;
+
+      final result = await authenticatedClient.query(queryOption);
+
+      expect(result.data['result'], 'success');
+      expect(result.hasException, false);
+    });
+  });
+}

--- a/test/fakers/fake_token_storage.dart
+++ b/test/fakers/fake_token_storage.dart
@@ -6,10 +6,4 @@ class FakeTokenStorage extends Fake implements TokenStorage<OAuth2Token> {
   Future<OAuth2Token> read() async {
     return OAuth2Token(accessToken: 'fake token');
   }
-
-  @override
-  Future<void> write(OAuth2Token token) {
-    // TODO update later
-    return null;
-  }
 }

--- a/test/fakers/fake_token_storage.dart
+++ b/test/fakers/fake_token_storage.dart
@@ -1,0 +1,15 @@
+import 'package:fresh_graphql/fresh_graphql.dart';
+import 'package:mockito/mockito.dart';
+
+class FakeTokenStorage extends Fake implements TokenStorage<OAuth2Token> {
+  @override
+  Future<OAuth2Token> read() async {
+    return OAuth2Token(accessToken: 'fake token');
+  }
+
+  @override
+  Future<void> write(OAuth2Token token) {
+    // TODO update later
+    return null;
+  }
+}

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -12,7 +12,8 @@ import 'package:survey/use_cases/get_profile_use_case.dart';
   GraphQLClient,
   GetProfileUseCase,
   ApiClient,
-  HttpClientAdapter
+  HttpClientAdapter,
+  QueryManager
 ])
 main() {
   // empty class to generate mock repository classes

--- a/test/mocks/generate_mocks.mocks.dart
+++ b/test/mocks/generate_mocks.mocks.dart
@@ -1,4 +1,5 @@
 import 'package:dio/src/adapter.dart' as _i7;
+import 'package:graphql/src/core/query_manager.dart' as _i8;
 import 'package:graphql/src/graphql_client.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:survey/api/http/api_client.dart' as _i6;
@@ -56,6 +57,15 @@ class MockApiClient extends _i1.Mock implements _i6.ApiClient {
 /// See the documentation for Mockito's code generation for more information.
 class MockHttpClientAdapter extends _i1.Mock implements _i7.HttpClientAdapter {
   MockHttpClientAdapter() {
+    _i1.throwOnMissingStub(this);
+  }
+}
+
+/// A class which mocks [QueryManager].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockQueryManager extends _i1.Mock implements _i8.QueryManager {
+  MockQueryManager() {
     _i1.throwOnMissingStub(this);
   }
 }

--- a/test/repositories/oauth_repository_test.dart
+++ b/test/repositories/oauth_repository_test.dart
@@ -39,4 +39,26 @@ main() {
       expect(result, throwsA(isA<BadRequest>()));
     });
   });
+
+  group('Validate refresh token', () {
+    test('When refresh successfully, it returns AuthTokenResponse', () async {
+      when(mockApiClient.refreshToken(any)).thenAnswer(
+          (_) async => AuthTokenResponseData.fromJson(oauthJsonData));
+
+      final result = await testedOAuthRepository.refreshToken("refresh token");
+
+      expect(result, isA<AuthTokenResponse>());
+      expect(result.accessToken, "access token");
+    });
+
+    test('When refresh unsuccessfully, it returns a NetworkException',
+        () async {
+      when(mockApiClient.refreshToken(any)).thenThrow(DioError(
+          response: Response(statusCode: 400), type: DioErrorType.RESPONSE));
+      final result = () => testedOAuthRepository.refreshToken("refresh token");
+
+      expect(result, throwsA(isA<NetworkExceptions>()));
+      expect(result, throwsA(isA<BadRequest>()));
+    });
+  });
 }

--- a/test/repositories/user_repository_test.dart
+++ b/test/repositories/user_repository_test.dart
@@ -53,7 +53,7 @@ main() {
   group('Validate isLoggedIn', () {
     test('When the user has logged in, it returns corresponding status',
         () async {
-          Get.put<TokenStorage<OAuth2Token>>(FakeTokenStorage());
+      Get.put<TokenStorage<OAuth2Token>>(FakeTokenStorage());
       fakeSharedPref.saveRefreshToken("fake refreshToken");
       final result = await testedUserRepository.isLoggedIn();
       expect(result, true);

--- a/test/repositories/user_repository_test.dart
+++ b/test/repositories/user_repository_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fresh_graphql/fresh_graphql.dart';
+import 'package:get/get.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:mockito/mockito.dart';
 import 'package:survey/api/graphql/graphql_client_provider.dart';
@@ -7,6 +9,7 @@ import 'package:survey/models/user.dart';
 import 'package:survey/repositories/user_repository.dart';
 
 import '../fakers/fake_shared_preferences_storage.dart';
+import '../fakers/fake_token_storage.dart';
 import '../mocks/generate_mocks.mocks.dart';
 
 main() {
@@ -50,6 +53,7 @@ main() {
   group('Validate isLoggedIn', () {
     test('When the user has logged in, it returns corresponding status',
         () async {
+          Get.put<TokenStorage<OAuth2Token>>(FakeTokenStorage());
       fakeSharedPref.saveRefreshToken("fake refreshToken");
       final result = await testedUserRepository.isLoggedIn();
       expect(result, true);

--- a/test/repositories/user_repository_test.dart
+++ b/test/repositories/user_repository_test.dart
@@ -14,8 +14,8 @@ import '../mocks/generate_mocks.mocks.dart';
 
 main() {
   final mockClient = MockGraphQLClient();
-  final graphqlClientProvider =
-      GraphQLClientProvider(injectedClient: mockClient);
+  final graphqlClientProvider = GraphQLClientProvider()
+    ..setGraphQLClient(mockClient);
   final fakeSharedPref = FakeSharedPreferencesStorage();
   TestWidgetsFlutterBinding.ensureInitialized();
 


### PR DESCRIPTION
## What happened 👀
Add unit test coverage to the `graphQLClient` part.

## Insight 📝

- Refactor the logic to refreshToken a bit -> we should go through OAuthRepository instead of calling ApiClient directly -> correcting architecture.
- Decoupling the dependencies injection of ApiClient/cache Store (HiveStore) /TokenStorage within the graphql client.
- Start testing the behavior of the GraphQL Client: 
  - Success (no auth)
  - Success with (auth)
  - Failed with auth_link -> it calls to `refreshToken()` once before failing request as it is an incorrect token is submitted to the real API.
 
## Proof Of Work 📹
Codecov ++++++ 🤑 